### PR TITLE
Fix flake8 formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,9 @@ load_dotenv()
 MONGODB_URI = os.getenv('MONGODB_URI')
 MONGODB_DB_NAME = os.getenv('MONGODB_DB_NAME', 'campus_marketplace')
 jwt_secret_from_env = os.getenv('JWT_SECRET')
-app_env = os.getenv('APP_ENV', os.getenv('FLASK_ENV', 'development')).strip().lower()
+app_env = os.getenv(
+    'APP_ENV', os.getenv('FLASK_ENV', 'development')
+).strip().lower()
 is_production = app_env == 'production'
 
 if not jwt_secret_from_env:


### PR DESCRIPTION
## Summary
- Fixed the Flake8 formatting warning in `app.py`.
- Wrapped the long `os.getenv(...)` assignment to satisfy the line-length rule.
- Added the missing newline at the end of the file.

## Linked Issue
Relates to (/issues/53)

## Changes
- Reformatted the `app_env` assignment in `app.py`.
- Added the trailing newline required by Flake8.
- No functional logic was changed.

## How Tested (required)
- [✅] Ran locally: `get_errors` on `app.py`
- [✅] Tests: Flake8 warnings cleared for `app.py`
- [x] CI checks: not run manually

## Screenshots / Demo (if user-facing)
- Not applicable. This is a formatting-only backend change.

## Risk / Rollback
- Risk: very low, since this is formatting-only.
- Rollback plan: revert commit `1fd75cb` if needed.

## Checklist
- [✅] I linked an Issue
- [✅] I used a branch (not direct to `main`)
- [✅] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [✅] I added/updated tests if relevant