### PR TITLE
Fix malformed JWT subject handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ items = db.items
 try:
     client.admin.command('ping')
     users.create_index('email', unique=True)
-    items.create_index('createdAt', -1)
+    items.create_index([('createdAt', -1)])
 except Exception as exc:
     raise RuntimeError(
         'MongoDB connection failed. Check Atlas username/password and '
@@ -76,7 +76,12 @@ UPLOAD_FOLDER = Path(__file__).resolve().parent / 'uploads'
 UPLOAD_FOLDER.mkdir(exist_ok=True)
 MAX_IMAGE_UPLOAD_BYTES = 5 * 1024 * 1024
 ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.gif', '.webp'}
-ALLOWED_IMAGE_MIMETYPES = {'image/jpeg', 'image/png', 'image/gif', 'image/webp'}
+ALLOWED_IMAGE_MIMETYPES = {
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+}
 
 app.config['MAX_CONTENT_LENGTH'] = MAX_IMAGE_UPLOAD_BYTES
 app.config['UPLOAD_FOLDER'] = str(UPLOAD_FOLDER)
@@ -114,6 +119,13 @@ def build_user_payload(user_doc):
         'email': user_doc['email'],
         'isVerified': user_doc.get('isVerified', False),
     }
+
+
+def parse_object_id(value):
+    try:
+        return ObjectId(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def is_allowed_email(email):
@@ -172,12 +184,18 @@ def upload_image():
 
     file_extension = os.path.splitext(safe_filename)[1].lower()
     if file_extension not in ALLOWED_IMAGE_EXTENSIONS:
-        return json_error('Only JPG, PNG, GIF, and WebP images are allowed.', 400)
+        return json_error(
+            'Only JPG, PNG, GIF, and WebP images are allowed.',
+            400,
+        )
 
     if uploaded_file.mimetype not in ALLOWED_IMAGE_MIMETYPES:
         return json_error('Only image uploads are allowed.', 400)
 
-    if request.content_length and request.content_length > MAX_IMAGE_UPLOAD_BYTES:
+    if (
+        request.content_length
+        and request.content_length > MAX_IMAGE_UPLOAD_BYTES
+    ):
         return json_error('Image must be smaller than 5 MB.', 413)
 
     stored_filename = f"{uuid4().hex}-{safe_filename}"
@@ -289,9 +307,13 @@ def me():
     except jwt.PyJWTError:
         return json_error('Invalid or expired token.', 401)
 
-    user_doc = users.find_one({'_id': ObjectId(payload['sub'])})
+    user_id = parse_object_id(payload.get('sub'))
+    if not user_id:
+        return json_error('Invalid or expired token.', 401)
+
+    user_doc = users.find_one({'_id': user_id})
     if not user_doc:
-        return json_error('User not found.', 404)
+        return json_error('Invalid or expired token.', 401)
 
     return jsonify({'user': build_user_payload(user_doc)})
 
@@ -303,20 +325,16 @@ def get_items():
         page = request.args.get('page', 1, type=int)
         limit = request.args.get('limit', 20, type=int)
         category = request.args.get('category', None)
-        
         # Validate pagination
         if page < 1:
             page = 1
         if limit < 1 or limit > 100:
             limit = 20
-        
         skip = (page - 1) * limit
-        
         # Build query filter
         query_filter = {}
         if category:
             query_filter['category'] = category
-        
         # Fetch items
         items_list = list(
             items.find(query_filter)
@@ -324,14 +342,11 @@ def get_items():
             .skip(skip)
             .limit(limit)
         )
-        
         # Convert ObjectIds to strings
         for item in items_list:
             item['_id'] = str(item['_id'])
             item['sellerId'] = str(item['sellerId'])
-        
         total = items.count_documents(query_filter)
-        
         return jsonify({
             'items': items_list,
             'pagination': {
@@ -358,10 +373,13 @@ def create_item():
     except jwt.PyJWTError:
         return json_error('Invalid or expired token.', 401)
 
-    seller_id = payload['sub']
-    user_doc = users.find_one({'_id': ObjectId(seller_id)})
+    seller_id = parse_object_id(payload.get('sub'))
+    if not seller_id:
+        return json_error('Invalid or expired token.', 401)
+
+    user_doc = users.find_one({'_id': seller_id})
     if not user_doc:
-        return json_error('User not found.', 404)
+        return json_error('Invalid or expired token.', 401)
 
     data = request.get_json(silent=True) or {}
     required_fields = ['title', 'description', 'price', 'category', 'location']
@@ -383,7 +401,7 @@ def create_item():
         return json_error('Price must be a valid number.', 400)
 
     item_doc = {
-        'sellerId': ObjectId(seller_id),
+        'sellerId': seller_id,
         'sellerName': f"{user_doc['firstName']} {user_doc['lastName']}",
         'title': str(data['title']).strip(),
         'description': str(data['description']).strip(),
@@ -400,7 +418,6 @@ def create_item():
         result = items.insert_one(item_doc)
         item_doc['_id'] = str(result.inserted_id)
         item_doc['sellerId'] = str(item_doc['sellerId'])
-        
         return jsonify({
             'message': 'Item created successfully.',
             'item': item_doc,


### PR DESCRIPTION

## Summary
- Fixes unsafe ObjectId conversion when JWT sub is malformed.
- Ensures endpoints return 401 for malformed-but-decodable tokens instead of raising a    server error.
- Applies the same guard to item-creation endpoint for consistent auth handling.


## Linked Issue
Closes #43 

## Changes
- Validate token sub before converting to ObjectId in app.py.
- Added parse_object_id() helper to safely parse ObjectId values.
- Return 401 Invalid or expired token for malformed sub values in /api/auth/me and /api/items POST.
- Minor linting/format cleanups to app.py.


## How Tested (required)
- [x] Ran locally (backend): source .venv/bin/activate
python app.py
- [x]  Ran locally (frontend dev server): cd Frontend
npm run dev
- [ ] Tests: none added.
- [x] CI checks: (link if helpful)

## Screenshots / Demo (if user-facing)
- Demo link (optional):

## Risk / Rollback
- Risk: Some clients that relied on previous 500/404 behavior for malformed tokens may need to handle 401 instead.
- Rollback plan: Revert the commit 54cd2ec on branch For-bugs or restore previous [app.py].

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
