### PR TITLE
Fix signup submission lifecycle

### DIFF
--- a/Frontend/src/routes/Signup.jsx
+++ b/Frontend/src/routes/Signup.jsx
@@ -130,6 +130,10 @@ export default function Signup() {
   async function handleSubmit(event) {
     event.preventDefault()
 
+    if (isLoading) {
+      return
+    }
+
     const normalizedValues = {
       ...formValues,
       firstName: formValues.firstName.trim(),
@@ -164,16 +168,19 @@ export default function Signup() {
         body: JSON.stringify(normalizedValues),
       })
 
-      navigate('/login', {
-        state: {
-          message: response.message || 'Account created. Please log in.',
-          email: normalizedValues.email,
-        },
-      })
+      if (!response?.token || !response?.user) {
+        throw new Error('Signup completed but no session was returned.')
+      }
+
+      localStorage.setItem('campusMarketplaceToken', response.token)
+      localStorage.setItem('campusMarketplaceUser', JSON.stringify(response.user))
+
+      setSubmitStatus({ type: '', message: '' })
+      navigate('/dashboard', { replace: true })
     } catch (error) {
       setSubmitStatus({
         type: 'error',
-        message: error.message || 'Signup failed. Please try again.',
+        message: error instanceof Error ? error.message : 'Signup failed. Please try again.',
       })
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
## Summary
- Fixed the signup submission lifecycle so a valid signup now completes once, handles backend errors cleanly, and does not stop midway.
- Persisted the returned auth session on signup success and routed the user into the authenticated dashboard flow.
- Added a duplicate-submit guard so the form cannot send overlapping requests.

## Linked Issue
Closes #42

## Changes
- Updated `Frontend/src/routes/Signup.jsx` to block repeated submits while a request is in flight.
- Changed the success path to store the returned token and user in localStorage, then redirect to `/dashboard`.
- Kept validation and error handling on the same submit path so field errors and backend failures surface consistently.

## How Tested (required)
- [x] Ran locally: `source .venv/bin/activate && python app.py`
- [x] Ran locally: `npm --prefix Frontend run dev -- --host 127.0.0.1`
- [x] Tests: `npm --prefix Frontend run build`
- [x] CI checks: N/A locally; production frontend build completed successfully

## Screenshots / Demo (if user-facing)
- Before: signup could stop short of a complete authenticated flow.
- After: valid signup stores session data and redirects to the dashboard; invalid submit shows inline errors.
- Demo link (optional): N/A

## Risk / Rollback
- Risk: if the backend ever stops returning `token` and `user` on signup, the frontend now surfaces that as an error instead of silently continuing.
- Rollback plan: revert commit `f5856b7` or revert the `Signup.jsx` changes.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant