### PR TITLE
fix: do not issue JWT token before email verification

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,11 +365,9 @@ def signup():
         return json_error('An account with this email already exists.', 409)
 
     saved_user = users.find_one({'_id': result.inserted_id})
-    token = issue_token(saved_user)
 
     return jsonify({
-        'message': 'Account created successfully.',
-        'token': token,
+        'message': 'Account created successfully. Please verify your email before logging in.',
         'user': build_user_payload(saved_user),
     }), 201
 
@@ -389,6 +387,9 @@ def login():
 
     if not check_password_hash(user_doc['passwordHash'], password):
         return json_error('Invalid email or password.', 401)
+
+    if not user_doc.get('isVerified', False):
+        return json_error('Please verify your email address before logging in.', 403)
 
     token = issue_token(user_doc)
 


### PR DESCRIPTION
Signup no longer returns a token for unverified accounts. Login now blocks unverified users with a 403 before issuing a token, preventing bypass of the email verification requirement.

Fixes #38

## Summary
- Signup no longer issues a JWT token so unverified accounts cannot authenticate immediately after registration
- Login now returns a 403 for unverified users before issuing a token, enforcing the email verification gate
- Prevents the bypass where a signup token could be used to skip email verification entirely

## Linked Issue
Closes #38

## Changes
- Removed `issue_token()` call from `signup()` so new accounts no longer receive a token on registration
- Added `isVerified` check in `login()` that returns 403 if the user has not verified their email
- Updated signup response message to instruct users to verify their email before logging in

## How Tested (required)
- [x] Ran locally: `python app.py` — tested signup returns no token, login with unverified account returns 403, login with verified account succeeds
- [x] Tests: manually verified all three cases via Postman/curl
- [x] CI checks:

## Risk / Rollback
- Risk: Existing unverified users in the database will be blocked from logging in until they verify their email
- Rollback plan: Revert commit `7f9dd0f` to restore token issuance on signup and remove the `isVerified` login check

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
