### PR TITLE
Fix listing image persistence across relogin

### DIFF
--- a/Frontend/src/components/ItemCard.jsx
+++ b/Frontend/src/components/ItemCard.jsx
@@ -1,5 +1,28 @@
 import { API_ORIGIN } from '../services/api'
 
+function getPrimaryImageValue(item) {
+  if (item?.image) {
+    if (typeof item.image === 'string') {
+      return item.image
+    }
+    if (typeof item.image === 'object' && item.image.url) {
+      return item.image.url
+    }
+  }
+
+  if (Array.isArray(item?.images) && item.images.length > 0) {
+    const first = item.images[0]
+    if (typeof first === 'string') {
+      return first
+    }
+    if (first && typeof first === 'object' && first.url) {
+      return first.url
+    }
+  }
+
+  return ''
+}
+
 function resolveImageUrl(image) {
   if (!image) {
     return ''
@@ -13,7 +36,7 @@ function resolveImageUrl(image) {
 }
 
 export default function ItemCard({ item }) {
-  const imageSrc = resolveImageUrl(item.image)
+  const imageSrc = resolveImageUrl(getPrimaryImageValue(item))
   const price = typeof item.price === 'number' ? item.price : Number(item.price)
   const formattedPrice = Number.isFinite(price)
     ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(price)

--- a/app.py
+++ b/app.py
@@ -170,13 +170,18 @@ def serialize_item_document(item_doc):
     images = item_doc.get('images')
     if isinstance(images, list) and images:
         first = images[0]
-        # If images are objects with 'url', expose legacy `image` as URL string
-        if isinstance(first, dict) and first.get('url'):
+        # If images are objects with 'url', expose legacy `image` as URL string.
+        if isinstance(first, dict):
             item_doc['image'] = first.get('url')
         else:
             item_doc['image'] = first
     elif item_doc.get('image'):
-        item_doc['images'] = [item_doc['image']]
+        image_value = item_doc.get('image')
+        if isinstance(image_value, dict):
+            item_doc['image'] = image_value.get('url')
+            item_doc['images'] = [image_value]
+        else:
+            item_doc['images'] = [image_value]
     else:
         item_doc['images'] = []
         item_doc['image'] = None


### PR DESCRIPTION

## Summary
- Fixed listing image persistence after logout/login by making image handling compatible with both legacy and new payload shapes.
- Updated backend serialization to consistently expose a usable [image] URL, even when [images] contains objects like [{ url, alt, order }].
- Updated frontend item card rendering to safely resolve image sources from [image] or [images[]], preventing broken thumbnails after re-authentication.


## Linked Issue
Closes #<66>  
(or) Relates to #<66>

## Changes
- Improved [serialize_item_document()] image normalization logic.
- Ensures [image]is always set to a string URL when possible, including object-based image formats.
- Added resilient primary image selection logic to support:
[item.image]as string, [item.image] as object with [url], [item.images[0]] as string or object
- Kept existing URL resolution behavior for relative/absolute URLs.

## How Tested (required)
- [x] Ran locally: backend syntax + frontend production build
- [x] Tests: 
source .venv/bin/activate && python -m py_compile app.py (pass)
cd Frontend && npm run build (pass)
- [x] CI checks

## Screenshots / Demo (if user-facing)
Before: Listing image could disappear/break after logout and login due to payload shape mismatch.
After: Listing images render correctly after logout/login for both legacy and object-based image payloads.

## Risk / Rollback
- Risk: Existing records with unusual image shapes (missing [url]) may still fall back to placeholder image. If downstream code assumes only one image format, hidden edge cases may remain in non-card views.
- Rollback plan: Revert commit 05ca780 from branch fix/image-persistence-after-relogin. Redeploy and re-test listing image rendering paths.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
