### PR TITLE
Add composer status control and click-to-open post flow

### DIFF
--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -33,11 +33,13 @@ export default function Dashboard() {
     price: '',
     description: '',
     category: '',
+    status: 'active',
   })
   const [formErrors, setFormErrors] = useState({})
   const [submitMessage, setSubmitMessage] = useState('')
   const [submitError, setSubmitError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isComposerOpen, setIsComposerOpen] = useState(false)
 
   const imageInputRef = useRef(null)
   const previewObjectUrlRef = useRef('')
@@ -108,7 +110,12 @@ export default function Dashboard() {
   }
 
   function handleImageUpload() {
+    setIsComposerOpen(true)
     imageInputRef.current?.click()
+  }
+
+  function openComposer() {
+    setIsComposerOpen(true)
   }
 
   async function handleFileChange(event) {
@@ -183,6 +190,7 @@ export default function Dashboard() {
     }
     if (!formData.description.trim()) nextErrors.description = 'Description is required.'
     if (!formData.category.trim()) nextErrors.category = 'Category is required.'
+    if (!formData.status.trim()) nextErrors.status = 'Status is required.'
     if (!uploadedImageUrl) nextErrors.image = 'Please upload at least one image.'
 
     setFormErrors(nextErrors)
@@ -203,6 +211,7 @@ export default function Dashboard() {
         price: Number(formData.price),
         description: formData.description.trim(),
         category: formData.category.trim(),
+        status: formData.status.trim(),
         location: DEFAULT_ITEM_LOCATION,
         image: uploadedImageUrl,
       }
@@ -215,6 +224,7 @@ export default function Dashboard() {
         price: '',
         description: '',
         category: '',
+        status: 'active',
       })
       setFormErrors({})
       setUploadedImageUrl('')
@@ -240,6 +250,15 @@ export default function Dashboard() {
                   {firstName.slice(0, 1)}
                 </div>
                 <button
+                  className="composer-input"
+                  type="button"
+                  onClick={openComposer}
+                  aria-label="Open post composer"
+                  disabled={isSubmitting || isUploading}
+                >
+                  What's on your mind?
+                </button>
+                <button
                   className="composer-icon-button composer-camera-right"
                   type="button"
                   onClick={handleImageUpload}
@@ -250,7 +269,8 @@ export default function Dashboard() {
                 </button>
               </div>
 
-              <div className="composer-fields">
+              {isComposerOpen && (
+                <div className="composer-fields">
                 <input
                   name="title"
                   type="text"
@@ -283,6 +303,17 @@ export default function Dashboard() {
                 />
                 {formErrors.category && <p className="composer-feedback is-error">{formErrors.category}</p>}
 
+                <select
+                  name="status"
+                  value={formData.status}
+                  onChange={handleFormChange}
+                  className="composer-text-input"
+                >
+                  <option value="active">Active</option>
+                  <option value="draft">Draft</option>
+                </select>
+                {formErrors.status && <p className="composer-feedback is-error">{formErrors.status}</p>}
+
                 <textarea
                   name="description"
                   placeholder="Description"
@@ -294,29 +325,32 @@ export default function Dashboard() {
                 {formErrors.description && <p className="composer-feedback is-error">{formErrors.description}</p>}
 
                 {formErrors.image && <p className="composer-feedback is-error">{formErrors.image}</p>}
-              </div>
+                </div>
+              )}
 
-              {(uploadMessage || uploadError) && (
+              {isComposerOpen && (uploadMessage || uploadError) && (
                 <p className={`composer-feedback ${uploadError ? 'is-error' : 'is-success'}`} aria-live="polite">
                   {uploadError || uploadMessage}
                 </p>
               )}
 
-              {uploadPreviewUrl && (
+              {isComposerOpen && uploadPreviewUrl && (
                 <div className="composer-preview">
                   <img src={uploadPreviewUrl} alt="Selected upload preview" />
                 </div>
               )}
 
-              {(submitMessage || submitError) && (
+              {isComposerOpen && (submitMessage || submitError) && (
                 <p className={`composer-feedback ${submitError ? 'is-error' : 'is-success'}`} aria-live="polite">
                   {submitError || submitMessage}
                 </p>
               )}
 
-              <button className="composer-submit" type="submit" disabled={isSubmitting || isUploading}>
-                {isSubmitting ? 'Posting...' : 'Post Item'}
-              </button>
+              {isComposerOpen && (
+                <button className="composer-submit" type="submit" disabled={isSubmitting || isUploading}>
+                  {isSubmitting ? 'Posting...' : 'Post Item'}
+                </button>
+              )}
 
               <input
                 ref={imageInputRef}

--- a/app.py
+++ b/app.py
@@ -590,11 +590,11 @@ def create_item():
         return json_error('Price must be a valid number.', 400)
 
     status = (
-        str(data.get('status', 'available')).strip().lower() or 'available'
+        str(data.get('status', 'active')).strip().lower() or 'active'
     )
     if status not in ITEM_STATUSES:
         return json_error(
-            'Status must be one of: available, sold, pending.',
+            'Status must be one of: draft, active, sold, removed.',
             400,
         )
 


### PR DESCRIPTION
## Summary
- Fixed item image persistence so uploaded images still render after logout/login and page reload.
- Added robust image shape handling across backend + frontend (supports both legacy string URLs and object-based image entries).
- Improved posting UX by adding a status selector and making composer actions open consistently from both camera click and “What’s on your mind?” click.

## Linked Issue
Closes #68 

## Changes
- Backend:
  - Normalized serialized item image output so API responses always provide a usable primary image URL.
  - Updated item creation status default/validation message to align with current status schema (`draft | active | sold | removed`).
- Frontend:
  - Updated item card image resolution logic to support:
    - `image` as string
    - `image` as object with `url`
    - `images[0]` as string or object
  - Updated composer flow:
    - Added status select (`Active`, `Draft`) to post form.
    - Kept composer details hidden until user clicks camera or input prompt.
    - Ensured both triggers follow the same open-and-post behavior.

## How Tested (required)
- [x] Ran locally: backend + frontend
- [x] Tests:
  - `source .venv/bin/activate && python -m py_compile app.py` (pass)
  - `cd Frontend && npm run build` (pass)
- [x] CI checks: (add link after workflow runs)

## Screenshots / Demo (if user-facing)
- Before:
  - Image could disappear after logout/login in listing cards.
  - Composer controls always visible and status missing.
- After:
  - Image remains visible after logout/login and reload.
  - Composer opens only on click; status can be selected before posting.
- Demo link (optional): N/A

## Risk / Rollback
- Risk:
  - Legacy records with malformed image objects (missing `url`) may still show fallback image.
  - Status values from older clients could fail validation if not mapped.
- Rollback plan:
  - Revert the latest commits on the fix branch and redeploy.
  - Re-run local build checks to confirm rollback integrity.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant