### PR TITLE
Add multi-image uploads to post composer

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -808,6 +808,65 @@ h1 {
   object-fit: cover;
 }
 
+.composer-preview-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 0.5rem;
+  padding: 0.7rem;
+}
+
+.composer-thumb {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 72px;
+}
+
+.composer-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.composer-thumb-remove,
+.composer-clear-images {
+  border: none;
+  cursor: pointer;
+}
+
+.composer-thumb-remove {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.composer-clear-images {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0.4rem 0.7rem 0.7rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.composer-clear-images:hover,
+.composer-thumb-remove:hover {
+  background: rgba(77, 195, 255, 0.18);
+  color: var(--text);
+}
+
 .composer-submit {
   border: none;
   border-radius: 10px;

--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -3,7 +3,19 @@ import { useNavigate } from 'react-router-dom'
 import { apiRequest, createItem, fetchItems } from '../services/api'
 
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
-const ALLOWED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif'])
+const MAX_IMAGE_COUNT = 5
+const ALLOWED_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/avif',
+  'image/bmp',
+  'image/tiff',
+  'image/heic',
+  'image/heif',
+  'image/x-icon',
+])
 const DEFAULT_ITEM_LOCATION = 'Campus'
 
 const STORIES = [
@@ -22,7 +34,7 @@ export default function Dashboard() {
   const [uploadMessage, setUploadMessage] = useState('')
   const [uploadError, setUploadError] = useState('')
   const [isUploading, setIsUploading] = useState(false)
-  const [uploadedImageUrl, setUploadedImageUrl] = useState('')
+  const [uploadedImages, setUploadedImages] = useState([])
 
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(true)
@@ -118,54 +130,81 @@ export default function Dashboard() {
     setIsComposerOpen(true)
   }
 
+  function removeUploadedImage(indexToRemove) {
+    setUploadedImages((current) => {
+      const nextImages = current.filter((_, index) => index !== indexToRemove)
+      updatePreviewUrl(nextImages[0] || '')
+      return nextImages
+    })
+    setFormErrors((prev) => ({ ...prev, image: '' }))
+  }
+
+  function clearUploadedImages() {
+    setUploadedImages([])
+    updatePreviewUrl('')
+    setFormErrors((prev) => ({ ...prev, image: '' }))
+  }
+
   async function handleFileChange(event) {
     const fileInput = event.target
-    const selectedFile = event.target.files?.[0]
-    if (!selectedFile) {
+    const selectedFiles = Array.from(event.target.files || [])
+    if (selectedFiles.length === 0) {
       return
     }
 
-    if (!ALLOWED_IMAGE_TYPES.has(selectedFile.type)) {
-      setUploadError('Please choose a JPG, PNG, GIF, or WebP image.')
+    if (selectedFiles.length + uploadedImages.length > MAX_IMAGE_COUNT) {
+      setUploadError(`Please choose up to ${MAX_IMAGE_COUNT} images total.`)
       setUploadMessage('')
       fileInput.value = ''
       return
     }
 
-    if (selectedFile.size > MAX_IMAGE_SIZE_BYTES) {
-      setUploadError('Please choose an image smaller than 5 MB.')
+    const unsupportedFile = selectedFiles.find((selectedFile) => !ALLOWED_IMAGE_TYPES.has(selectedFile.type))
+    if (unsupportedFile) {
+      setUploadError('Please choose a supported image type (JPG, PNG, GIF, WebP, AVIF, BMP, TIFF, HEIC, or ICO).')
       setUploadMessage('')
       fileInput.value = ''
       return
     }
 
-    const previewUrl = URL.createObjectURL(selectedFile)
-    updatePreviewUrl(previewUrl)
     setUploadError('')
-    setUploadMessage('Uploading image...')
+    setUploadMessage(`Uploading ${selectedFiles.length} image${selectedFiles.length > 1 ? 's' : ''}...`)
     setIsUploading(true)
 
     try {
-      const formData = new FormData()
-      formData.append('image', selectedFile)
+      const uploadedUrls = []
 
-      const result = await apiRequest('/uploads/image', {
-        method: 'POST',
-        body: formData,
-      })
+      for (const selectedFile of selectedFiles) {
+        if (selectedFile.size > MAX_IMAGE_SIZE_BYTES) {
+          throw new Error('Please choose images smaller than 5 MB each.')
+        }
 
-      if (result?.url) {
-        updatePreviewUrl(result.url)
-        setUploadedImageUrl(result.url)
+        const formData = new FormData()
+        formData.append('image', selectedFile)
+
+        const result = await apiRequest('/uploads/image', {
+          method: 'POST',
+          body: formData,
+        })
+
+        if (result?.url) {
+          uploadedUrls.push(result.url)
+        }
       }
 
-      setUploadMessage(result?.message || 'Image uploaded successfully.')
+      const nextImages = [...uploadedImages, ...uploadedUrls]
+      setUploadedImages(nextImages)
+      updatePreviewUrl(nextImages[0] || '')
+      setUploadMessage(
+        uploadedUrls.length > 1
+          ? `${uploadedUrls.length} images uploaded successfully.`
+          : 'Image uploaded successfully.',
+      )
       setUploadError('')
       setFormErrors((prev) => ({ ...prev, image: '' }))
     } catch (uploadErr) {
       setUploadError(uploadErr instanceof Error ? uploadErr.message : 'Image upload failed.')
-      setUploadMessage('Preview ready locally, but upload failed.')
-      setUploadedImageUrl('')
+        setUploadMessage('')
     } finally {
       setIsUploading(false)
       fileInput.value = ''
@@ -191,7 +230,7 @@ export default function Dashboard() {
     if (!formData.description.trim()) nextErrors.description = 'Description is required.'
     if (!formData.category.trim()) nextErrors.category = 'Category is required.'
     if (!formData.status.trim()) nextErrors.status = 'Status is required.'
-    if (!uploadedImageUrl) nextErrors.image = 'Please upload at least one image.'
+    if (uploadedImages.length === 0) nextErrors.image = 'Please upload at least one image.'
 
     setFormErrors(nextErrors)
     return Object.keys(nextErrors).length === 0
@@ -213,7 +252,8 @@ export default function Dashboard() {
         category: formData.category.trim(),
         status: formData.status.trim(),
         location: DEFAULT_ITEM_LOCATION,
-        image: uploadedImageUrl,
+        image: uploadedImages[0],
+        images: uploadedImages,
       }
 
       await createItem(payload)
@@ -227,7 +267,7 @@ export default function Dashboard() {
         status: 'active',
       })
       setFormErrors({})
-      setUploadedImageUrl('')
+      setUploadedImages([])
       updatePreviewUrl('')
       setUploadMessage('')
       setUploadError('')
@@ -337,6 +377,28 @@ export default function Dashboard() {
               {isComposerOpen && uploadPreviewUrl && (
                 <div className="composer-preview">
                   <img src={uploadPreviewUrl} alt="Selected upload preview" />
+                  {uploadedImages.length > 1 && (
+                    <div className="composer-preview-strip" aria-label="Selected image thumbnails">
+                      {uploadedImages.map((imageUrl, index) => (
+                        <div className="composer-thumb" key={`${imageUrl}-${index}`}>
+                          <img src={imageUrl} alt={`Selected image ${index + 1}`} />
+                          <button
+                            type="button"
+                            className="composer-thumb-remove"
+                            onClick={() => removeUploadedImage(index)}
+                            aria-label={`Remove image ${index + 1}`}
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {uploadedImages.length > 0 && (
+                    <button type="button" className="composer-clear-images" onClick={clearUploadedImages}>
+                      Clear images
+                    </button>
+                  )}
                 </div>
               )}
 
@@ -357,6 +419,7 @@ export default function Dashboard() {
                 className="composer-file-input"
                 type="file"
                 accept="image/*"
+                multiple
                 onChange={handleFileChange}
               />
             </form>

--- a/app.py
+++ b/app.py
@@ -239,12 +239,31 @@ app = Flask(__name__)
 UPLOAD_FOLDER = Path(__file__).resolve().parent / 'uploads'
 UPLOAD_FOLDER.mkdir(exist_ok=True)
 MAX_IMAGE_UPLOAD_BYTES = 5 * 1024 * 1024
-ALLOWED_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.gif', '.webp'}
+ALLOWED_IMAGE_EXTENSIONS = {
+    '.jpg',
+    '.jpeg',
+    '.png',
+    '.gif',
+    '.webp',
+    '.avif',
+    '.bmp',
+    '.tif',
+    '.tiff',
+    '.heic',
+    '.heif',
+    '.ico',
+}
 ALLOWED_IMAGE_MIMETYPES = {
     'image/jpeg',
     'image/png',
     'image/gif',
     'image/webp',
+    'image/avif',
+    'image/bmp',
+    'image/tiff',
+    'image/heic',
+    'image/heif',
+    'image/x-icon',
 }
 
 app.config['MAX_CONTENT_LENGTH'] = MAX_IMAGE_UPLOAD_BYTES
@@ -349,7 +368,7 @@ def upload_image():
     file_extension = os.path.splitext(safe_filename)[1].lower()
     if file_extension not in ALLOWED_IMAGE_EXTENSIONS:
         return json_error(
-            'Only JPG, PNG, GIF, and WebP images are allowed.',
+            'Only supported image formats are allowed (JPG, PNG, GIF, WebP, AVIF, BMP, TIFF, HEIC, HEIF, ICO).',
             400,
         )
 


### PR DESCRIPTION
## Summary
- Added support for uploading multiple images per item listing, up to 5 images total.
- Expanded image validation to accept common formats beyond PNG so the upload flow is more flexible.
- Updated the post composer to show image thumbnails, allow removing selected images, and submit an `images` array consistently.

## Linked Issue
Relates to #71 

## Changes
- Updated `Frontend/src/routes/Dashboard.jsx`:
  - Added multi-file image selection with a 5-image limit.
  - Stored uploaded image URLs in an `images` array and used the first image as the main preview.
  - Added remove/clear image controls in the composer preview.
- Updated `app.py`:
  - Broadened server-side upload validation to accept more common image formats.
  - Kept backend item creation compatible with the new `images` payload.
- Updated `Frontend/src/assets/styles/global.css`:
  - Added styles for the thumbnail strip, remove buttons, and clear-images action.

## How Tested (required)
- [x] Ran locally: `source .venv/bin/activate && python -m py_compile app.py`
- [x] Ran locally: `cd Frontend && npm run build`
- [x] Tests: backend compiled successfully, frontend production build completed successfully
- [x] CI checks: (add link if available)

## Screenshots / Demo (if user-facing)
- Before:
  - Only a single image was practical, and PNG support was too limited.
- After:
  - Users can select up to 5 images, preview them, remove individual images, and submit them together.
- Demo link (optional): N/A

## Risk / Rollback
- Risk:
  - Older records or uploads with unusual MIME types may still fall back to placeholder handling.
  - More images means more upload requests, which may slightly increase posting time.
- Rollback plan:
  - Revert commit `853801c` from branch `fix/multiple-image-uploads`.
  - Restore the previous single-image upload behavior if needed.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant