### PR TITLE
feat(dashboard): separate Browse & My Items; add item management

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -1132,3 +1132,138 @@ h1 {
     font-size: 0.95rem;
   }
 }
+
+/* Dashboard Tabs and Add Item Section */
+.add-item-section {
+  margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.dashboard-tabs {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 1rem;
+}
+
+.tab-button {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 160ms ease;
+}
+
+.tab-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text);
+}
+
+.tab-button.active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #001220;
+  font-weight: 700;
+}
+
+.button-sm {
+  min-width: 100px;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+/* My Items Section */
+.my-items-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.my-item-card {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.my-item-card .post-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.my-item-card .post-body {
+  margin-top: 0.4rem;
+}
+
+/* Item Edit Form */
+.item-edit-form {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.edit-field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.edit-field label {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.edit-input {
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: all 160ms ease;
+}
+
+.edit-input:hover {
+  border-color: rgba(77, 195, 255, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.edit-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: rgba(77, 195, 255, 0.08);
+}
+
+.edit-actions {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: flex-end;
+  margin-top: 0.4rem;
+}
+
+.edit-actions .button {
+  min-width: auto;
+  padding: 0.55rem 1rem;
+}
+
+/* Item Status Badge */
+.item-status-badge {
+  margin-top: 0.8rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.status-value {
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: capitalize;
+}

--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -38,8 +38,13 @@ export default function Dashboard({ currency }) {
   const [uploadedImages, setUploadedImages] = useState([])
 
   const [items, setItems] = useState([])
+  const [userItems, setUserItems] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+
+  const [activeSection, setActiveSection] = useState('browse')
+  const [editingItemId, setEditingItemId] = useState(null)
+  const [editFormData, setEditFormData] = useState({})
 
   const [formData, setFormData] = useState({
     title: '',
@@ -95,6 +100,12 @@ export default function Dashboard({ currency }) {
       setError(null)
       const data = await fetchItems(1, 20)
       setItems(data.items || [])
+      
+      // Filter user's items from all items
+      if (user) {
+        const filtered = (data.items || []).filter((item) => item.sellerId === user._id)
+        setUserItems(filtered)
+      }
     } catch (err) {
       setError(err.message || 'Failed to load items')
       console.error('Error fetching items:', err)
@@ -221,6 +232,44 @@ export default function Dashboard({ currency }) {
     setSubmitMessage('')
   }
 
+  function startEditingItem(item) {
+    setEditingItemId(item._id)
+    setEditFormData({
+      price: formatPriceFromUsd(item.price, currency),
+      itemStatus: item.itemStatus || 'sell',
+    })
+  }
+
+  function cancelEditingItem() {
+    setEditingItemId(null)
+    setEditFormData({})
+  }
+
+  function handleEditFormChange(event) {
+    const { name, value } = event.target
+    setEditFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  async function saveItemChanges(itemId) {
+    try {
+      const payload = {
+        price: convertDisplayPriceToUsd(editFormData.price, currency),
+        itemStatus: editFormData.itemStatus,
+      }
+
+      await apiRequest(`/items/${itemId}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      })
+
+      await loadItems()
+      setEditingItemId(null)
+      setEditFormData({})
+    } catch (err) {
+      console.error('Error updating item:', err)
+    }
+  }
+
   function validateForm() {
     const nextErrors = {}
     const priceValue = Number(formData.price)
@@ -285,196 +334,325 @@ export default function Dashboard({ currency }) {
     <main className="page-shell marketplace-shell">
       <section className="feed-layout">
         <section className="feed-main-col">
-          <section className="feed-panel composer" aria-label="Post composer">
-            <form className="composer-form" onSubmit={handlePostItemSubmit} noValidate>
-              <div className="composer-row">
-                <div className="avatar-badge" aria-hidden="true">
-                  {firstName.slice(0, 1)}
-                </div>
-                <button
-                  className="composer-input"
-                  type="button"
-                  onClick={openComposer}
-                  aria-label="Open post composer"
-                  disabled={isSubmitting || isUploading}
-                >
-                  What's on your mind?
-                </button>
-                <button
-                  className="composer-icon-button composer-camera-right"
-                  type="button"
-                  onClick={handleImageUpload}
-                  aria-label="Upload image"
-                  disabled={isUploading || isSubmitting}
-                >
-                  📷
-                </button>
-              </div>
-
-              {isComposerOpen && (
-                <div className="composer-fields">
-                <input
-                  name="title"
-                  type="text"
-                  placeholder="Title"
-                  value={formData.title}
-                  onChange={handleFormChange}
-                  className="composer-text-input"
-                />
-                {formErrors.title && <p className="composer-feedback is-error">{formErrors.title}</p>}
-
-                <input
-                  name="price"
-                  type="number"
-                  min={priceInputMeta.min}
-                  step={priceInputMeta.step}
-                  placeholder={priceInputMeta.placeholder}
-                  value={formData.price}
-                  onChange={handleFormChange}
-                  className="composer-text-input"
-                />
-                {formErrors.price && <p className="composer-feedback is-error">{formErrors.price}</p>}
-
-                <input
-                  name="category"
-                  type="text"
-                  placeholder="Category"
-                  value={formData.category}
-                  onChange={handleFormChange}
-                  className="composer-text-input"
-                />
-                {formErrors.category && <p className="composer-feedback is-error">{formErrors.category}</p>}
-
-                <select
-                  name="status"
-                  value={formData.status}
-                  onChange={handleFormChange}
-                  className="composer-text-input"
-                >
-                  <option value="active">Active</option>
-                  <option value="draft">Draft</option>
-                </select>
-                {formErrors.status && <p className="composer-feedback is-error">{formErrors.status}</p>}
-
-                <textarea
-                  name="description"
-                  placeholder="Description"
-                  value={formData.description}
-                  onChange={handleFormChange}
-                  className="composer-textarea"
-                  rows={4}
-                />
-                {formErrors.description && <p className="composer-feedback is-error">{formErrors.description}</p>}
-
-                {formErrors.image && <p className="composer-feedback is-error">{formErrors.image}</p>}
-                </div>
-              )}
-
-              {isComposerOpen && (uploadMessage || uploadError) && (
-                <p className={`composer-feedback ${uploadError ? 'is-error' : 'is-success'}`} aria-live="polite">
-                  {uploadError || uploadMessage}
-                </p>
-              )}
-
-              {isComposerOpen && uploadPreviewUrl && (
-                <div className="composer-preview">
-                  <img src={uploadPreviewUrl} alt="Selected upload preview" />
-                  {uploadedImages.length > 1 && (
-                    <div className="composer-preview-strip" aria-label="Selected image thumbnails">
-                      {uploadedImages.map((imageUrl, index) => (
-                        <div className="composer-thumb" key={`${imageUrl}-${index}`}>
-                          <img src={imageUrl} alt={`Selected image ${index + 1}`} />
-                          <button
-                            type="button"
-                            className="composer-thumb-remove"
-                            onClick={() => removeUploadedImage(index)}
-                            aria-label={`Remove image ${index + 1}`}
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {uploadedImages.length > 0 && (
-                    <button type="button" className="composer-clear-images" onClick={clearUploadedImages}>
-                      Clear images
-                    </button>
-                  )}
-                </div>
-              )}
-
-              {isComposerOpen && (submitMessage || submitError) && (
-                <p className={`composer-feedback ${submitError ? 'is-error' : 'is-success'}`} aria-live="polite">
-                  {submitError || submitMessage}
-                </p>
-              )}
-
-              {isComposerOpen && (
-                <button className="composer-submit" type="submit" disabled={isSubmitting || isUploading}>
-                  {isSubmitting ? 'Posting...' : 'Post Item'}
-                </button>
-              )}
-
-              <input
-                ref={imageInputRef}
-                className="composer-file-input"
-                type="file"
-                accept="image/*"
-                multiple
-                onChange={handleFileChange}
-              />
-            </form>
+          {/* Add Item Button */}
+          <section className="add-item-section">
+            <button
+              className="button button-primary"
+              onClick={() => {
+                setActiveSection('myItems')
+                setIsComposerOpen(true)
+              }}
+            >
+              + Add Item
+            </button>
           </section>
 
-          <section className="stories-row" aria-label="Stories">
-            {STORIES.map((story) => (
-              <article className="story-card" key={story}>
-                <span>{story}</span>
-              </article>
-            ))}
+          {/* Section Tabs */}
+          <section className="dashboard-tabs">
+            <button
+              className={`tab-button ${activeSection === 'browse' ? 'active' : ''}`}
+              onClick={() => setActiveSection('browse')}
+            >
+              Browse All Items
+            </button>
+            <button
+              className={`tab-button ${activeSection === 'myItems' ? 'active' : ''}`}
+              onClick={() => setActiveSection('myItems')}
+            >
+              My Items
+            </button>
           </section>
 
-          <section className="feed-post-list" aria-label="Marketplace feed posts">
-            {loading ? (
-              <div className="loading-state">
-                <p>Loading marketplace items...</p>
-              </div>
-            ) : error ? (
-              <div className="error-state">
-                <p>Error: {error}</p>
-              </div>
-            ) : items.length === 0 ? (
-              <div className="empty-state">
-                <p>No items available yet.</p>
-              </div>
-            ) : (
-              items.map((item) => (
-                <article className="feed-panel post-card" key={item._id}>
-                  <header className="post-header">
-                    <div className="avatar-badge" aria-hidden="true">
-                      {(item.sellerName || 'S').slice(0, 1)}
-                    </div>
-                    <div>
-                      <strong>{item.sellerName || 'Seller'}</strong>
-                      <p>{item.location || 'Campus'}</p>
-                    </div>
-                  </header>
-                  <div className="post-image" aria-hidden="true" />
-                  <div className="post-body">
-                    <div className="post-price">{formatPriceFromUsd(item.price, currency)}</div>
-                    <h2>{item.title}</h2>
-                    <p>{item.description}</p>
+          {/* Composer - Only shown in My Items section */}
+          {activeSection === 'myItems' && (
+            <section className="feed-panel composer" aria-label="Post composer">
+              <form className="composer-form" onSubmit={handlePostItemSubmit} noValidate>
+                <div className="composer-row">
+                  <div className="avatar-badge" aria-hidden="true">
+                    {firstName.slice(0, 1)}
                   </div>
-                  <footer className="post-actions" aria-label="Post actions">
-                    <button type="button">Like</button>
-                    <button type="button">Comment</button>
-                    <button type="button">Send Message</button>
-                  </footer>
+                  <button
+                    className="composer-input"
+                    type="button"
+                    onClick={openComposer}
+                    aria-label="Open post composer"
+                    disabled={isSubmitting || isUploading}
+                  >
+                    What's on your mind?
+                  </button>
+                  <button
+                    className="composer-icon-button composer-camera-right"
+                    type="button"
+                    onClick={handleImageUpload}
+                    aria-label="Upload image"
+                    disabled={isUploading || isSubmitting}
+                  >
+                    📷
+                  </button>
+                </div>
+
+                {isComposerOpen && (
+                  <div className="composer-fields">
+                    <input
+                      name="title"
+                      type="text"
+                      placeholder="Title"
+                      value={formData.title}
+                      onChange={handleFormChange}
+                      className="composer-text-input"
+                    />
+                    {formErrors.title && <p className="composer-feedback is-error">{formErrors.title}</p>}
+
+                    <input
+                      name="price"
+                      type="number"
+                      min={priceInputMeta.min}
+                      step={priceInputMeta.step}
+                      placeholder={priceInputMeta.placeholder}
+                      value={formData.price}
+                      onChange={handleFormChange}
+                      className="composer-text-input"
+                    />
+                    {formErrors.price && <p className="composer-feedback is-error">{formErrors.price}</p>}
+
+                    <input
+                      name="category"
+                      type="text"
+                      placeholder="Category"
+                      value={formData.category}
+                      onChange={handleFormChange}
+                      className="composer-text-input"
+                    />
+                    {formErrors.category && <p className="composer-feedback is-error">{formErrors.category}</p>}
+
+                    <select
+                      name="status"
+                      value={formData.status}
+                      onChange={handleFormChange}
+                      className="composer-text-input"
+                    >
+                      <option value="active">Active</option>
+                      <option value="draft">Draft</option>
+                    </select>
+                    {formErrors.status && <p className="composer-feedback is-error">{formErrors.status}</p>}
+
+                    <textarea
+                      name="description"
+                      placeholder="Description"
+                      value={formData.description}
+                      onChange={handleFormChange}
+                      className="composer-textarea"
+                      rows={4}
+                    />
+                    {formErrors.description && <p className="composer-feedback is-error">{formErrors.description}</p>}
+
+                    {formErrors.image && <p className="composer-feedback is-error">{formErrors.image}</p>}
+                  </div>
+                )}
+
+                {isComposerOpen && (uploadMessage || uploadError) && (
+                  <p className={`composer-feedback ${uploadError ? 'is-error' : 'is-success'}`} aria-live="polite">
+                    {uploadError || uploadMessage}
+                  </p>
+                )}
+
+                {isComposerOpen && uploadPreviewUrl && (
+                  <div className="composer-preview">
+                    <img src={uploadPreviewUrl} alt="Selected upload preview" />
+                    {uploadedImages.length > 1 && (
+                      <div className="composer-preview-strip" aria-label="Selected image thumbnails">
+                        {uploadedImages.map((imageUrl, index) => (
+                          <div className="composer-thumb" key={`${imageUrl}-${index}`}>
+                            <img src={imageUrl} alt={`Selected image ${index + 1}`} />
+                            <button
+                              type="button"
+                              className="composer-thumb-remove"
+                              onClick={() => removeUploadedImage(index)}
+                              aria-label={`Remove image ${index + 1}`}
+                            >
+                              ×
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {uploadedImages.length > 0 && (
+                      <button type="button" className="composer-clear-images" onClick={clearUploadedImages}>
+                        Clear images
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {isComposerOpen && (submitMessage || submitError) && (
+                  <p className={`composer-feedback ${submitError ? 'is-error' : 'is-success'}`} aria-live="polite">
+                    {submitError || submitMessage}
+                  </p>
+                )}
+
+                {isComposerOpen && (
+                  <button className="composer-submit" type="submit" disabled={isSubmitting || isUploading}>
+                    {isSubmitting ? 'Posting...' : 'Post Item'}
+                  </button>
+                )}
+
+                <input
+                  ref={imageInputRef}
+                  className="composer-file-input"
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  onChange={handleFileChange}
+                />
+              </form>
+            </section>
+          )}
+
+          {/* Stories Row - Only shown in Browse section */}
+          {activeSection === 'browse' && (
+            <section className="stories-row" aria-label="Stories">
+              {STORIES.map((story) => (
+                <article className="story-card" key={story}>
+                  <span>{story}</span>
                 </article>
-              ))
-            )}
-          </section>
+              ))}
+            </section>
+          )}
+
+          {/* Content based on active section */}
+          {activeSection === 'browse' && (
+            <section className="feed-post-list" aria-label="Marketplace feed posts">
+              {loading ? (
+                <div className="loading-state">
+                  <p>Loading marketplace items...</p>
+                </div>
+              ) : error ? (
+                <div className="error-state">
+                  <p>Error: {error}</p>
+                </div>
+              ) : items.length === 0 ? (
+                <div className="empty-state">
+                  <p>No items available yet.</p>
+                </div>
+              ) : (
+                items.map((item) => (
+                  <article className="feed-panel post-card" key={item._id}>
+                    <header className="post-header">
+                      <div className="avatar-badge" aria-hidden="true">
+                        {(item.sellerName || 'S').slice(0, 1)}
+                      </div>
+                      <div>
+                        <strong>{item.sellerName || 'Seller'}</strong>
+                        <p>{item.location || 'Campus'}</p>
+                      </div>
+                    </header>
+                    <div className="post-image" aria-hidden="true" />
+                    <div className="post-body">
+                      <div className="post-price">{formatPriceFromUsd(item.price, currency)}</div>
+                      <h2>{item.title}</h2>
+                      <p>{item.description}</p>
+                    </div>
+                    <footer className="post-actions" aria-label="Post actions">
+                      <button type="button">Like</button>
+                      <button type="button">Comment</button>
+                      <button type="button">Send Message</button>
+                    </footer>
+                  </article>
+                ))
+              )}
+            </section>
+          )}
+
+          {/* My Items Section */}
+          {activeSection === 'myItems' && (
+            <section className="my-items-list" aria-label="My uploaded items">
+              {loading ? (
+                <div className="loading-state">
+                  <p>Loading your items...</p>
+                </div>
+              ) : userItems.length === 0 ? (
+                <div className="empty-state">
+                  <p>You haven't uploaded any items yet. Click "Add Item" to get started!</p>
+                </div>
+              ) : (
+                userItems.map((item) => (
+                  <article className="feed-panel my-item-card" key={item._id}>
+                    <header className="post-header">
+                      <div className="avatar-badge" aria-hidden="true">
+                        {firstName.slice(0, 1)}
+                      </div>
+                      <div>
+                        <strong>{firstName}</strong>
+                        <p>{item.location || 'Campus'}</p>
+                      </div>
+                    </header>
+                    <div className="post-image" aria-hidden="true" />
+                    <div className="post-body">
+                      {editingItemId === item._id ? (
+                        <div className="item-edit-form">
+                          <div className="edit-field">
+                            <label>Price</label>
+                            <input
+                              type="number"
+                              name="price"
+                              value={editFormData.price}
+                              onChange={handleEditFormChange}
+                              min={priceInputMeta.min}
+                              step={priceInputMeta.step}
+                              className="edit-input"
+                            />
+                          </div>
+                          <div className="edit-field">
+                            <label>Status</label>
+                            <select
+                              name="itemStatus"
+                              value={editFormData.itemStatus}
+                              onChange={handleEditFormChange}
+                              className="edit-input"
+                            >
+                              <option value="sell">For Sale</option>
+                              <option value="reserved">Reserved</option>
+                              <option value="sold">Sold</option>
+                              <option value="sold out">Sold Out</option>
+                            </select>
+                          </div>
+                          <div className="edit-actions">
+                            <button
+                              className="button button-primary button-sm"
+                              onClick={() => saveItemChanges(item._id)}
+                            >
+                              Save
+                            </button>
+                            <button
+                              className="button button-secondary button-sm"
+                              onClick={cancelEditingItem}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="post-price">{formatPriceFromUsd(item.price, currency)}</div>
+                          <h2>{item.title}</h2>
+                          <p>{item.description}</p>
+                          <div className="item-status-badge">
+                            Status: <span className="status-value">{item.itemStatus || 'sell'}</span>
+                          </div>
+                          <button
+                            className="button button-secondary button-sm"
+                            onClick={() => startEditingItem(item)}
+                          >
+                            Edit Price & Status
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </article>
+                ))
+              )}
+            </section>
+          )}
         </section>
       </section>
     </main>

--- a/Frontend/src/routes/Home.jsx
+++ b/Frontend/src/routes/Home.jsx
@@ -19,9 +19,6 @@ export default function Home() {
         </div>
 
         <div className="hero-actions">
-          <Link className="button button-secondary" to="/browse">
-            Browse Items
-          </Link>
           <Link className="button button-primary" to="/signup">
             Get Started
           </Link>


### PR DESCRIPTION

## Summary

- Move "Browse Items" off the Home page and into the Dashboard.
- Add tabbed Dashboard UI with "Browse All Items" and "My Items".
- Provide a prominent "+ Add Item" button and per-item edit controls (price + status).

## Linked Issue
Closes #78 

## Changes
- Removed "Browse Items" button from [Home.jsx].
- Added tabbed navigation and "My Items" UI in [Dashboard.jsx].
- Implemented "+ Add Item" button to open the composer in the My Items section.
- Implemented per-item edit form to change price and set status (sell, reserved, sold, sold out) and save changes via PUT [/items/:id].
- Added styles for tabs, add button, edit form, and status badges in [global.css].
- Commit: 4d25b97 on branch fix/multiple-image-uploads.

## How Tested (required)
- [x] Ran locally: 
1. Start dev server and log in as a test user.
2. Verify Home shows only "Get Started" and "Sign In".
3. Visit /dashboard — verify tabs, "+ Add Item", and My Items behavior.
4. Create an item via composer; ensure it appears in My Items.
5. Edit an item price/status and save; verify changes persist.
- [x] CI checks: 

## Screenshots / Demo (if user-facing)
- Before: Home had "Browse Items" on hero actions.
- After: Home no longer shows "Browse Items"; Dashboard has tabs and My Items edit UI.
- Demo link (optional): N/A

## Risk / Rollback
- Risk: PUT [/items/:id] updates depend on backend API shape; if API disagrees, saves may fail.
- Rollback plan: Revert commit 4d25b97 from branch fix/multiple-image-uploads and re-deploy previous branch.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
