### PR TITLE
For profiles: Profile UI, avatar upload, and navigation behavior

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Login from './routes/Login'
 import Signup from './routes/Signup'
 import Dashboard from './routes/Dashboard'
 import Profile from './routes/Profile'
+import EditProfile from './routes/EditProfile'
 import { CURRENCY_OPTIONS, DEFAULT_CURRENCY } from './services/currency'
 
 const CURRENCY_STORAGE_KEY = 'campusMarketplaceCurrency'
@@ -77,6 +78,16 @@ export default function App() {
           element={
             authSession.token ? (
               <Profile currency={currency} />
+            ) : (
+              <Navigate to="/login" replace state={{ message: 'Please log in first.' }} />
+            )
+          }
+        />
+        <Route
+          path="/profile/edit"
+          element={
+            authSession.token ? (
+              <EditProfile />
             ) : (
               <Navigate to="/login" replace state={{ message: 'Please log in first.' }} />
             )

--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -251,6 +251,15 @@ input {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.profile-avatar-img {
+  width: 84px;
+  height: 84px;
+  border-radius: 24px;
+  object-fit: cover;
+  display: block;
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
 .profile-hero-copy h1 {
   margin-top: 0.25rem;
 }

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -24,6 +24,14 @@ export default function Navbar({
       return
     }
 
+    // If the user is authenticated, keep them inside the authenticated
+    // dashboard experience instead of sending them back to the public home
+    // page. Only unauthenticated users are routed to the public `/` home.
+    if (isAuthenticated) {
+      navigate('/dashboard')
+      return
+    }
+
     navigate('/')
   }
 

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -13,6 +13,8 @@ export default function Navbar({
   const location = useLocation()
   const navigate = useNavigate()
   const isDashboard = location.pathname === '/dashboard'
+  // Show the authenticated (dashboard-style) nav when user is signed in
+  const showAuthNav = isDashboard || isAuthenticated
   const [showSignOutModal, setShowSignOutModal] = useState(false)
   const [currencyMenuOpen, setCurrencyMenuOpen] = useState(false)
 
@@ -120,7 +122,7 @@ export default function Navbar({
                   </div>
                 )}
               </div>
-            {isDashboard ? (
+            {showAuthNav ? (
               <>
                 <button className="nav-pill" type="button" onClick={handleHome}>
                   Home
@@ -148,7 +150,6 @@ export default function Navbar({
                 <NavLink to="/" end>
                   Home
                 </NavLink>
-                <NavLink to="/browse">Browse</NavLink>
                 {isAuthenticated ? <NavLink to="/profile">Profile</NavLink> : <NavLink to="/login">Login</NavLink>}
                 {!isAuthenticated ? <NavLink to="/signup">Sign Up</NavLink> : null}
                 {isAuthenticated ? (

--- a/Frontend/src/routes/EditProfile.jsx
+++ b/Frontend/src/routes/EditProfile.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { fetchProfile, updateProfile } from '../services/api'
+
+export default function EditProfile() {
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ firstName: '', lastName: '', location: '' })
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let isActive = true
+    async function load() {
+      try {
+        const data = await fetchProfile()
+        if (!isActive) return
+        const user = data?.user || {}
+        setForm({
+          firstName: user.firstName || '',
+          lastName: user.lastName || '',
+          location: user.location || '',
+        })
+      } catch (err) {
+        if (!isActive) return
+        setError(err?.message || 'Unable to load profile')
+      }
+    }
+    load()
+    return () => {
+      isActive = false
+    }
+  }, [])
+
+  function onChange(e) {
+    const { name, value } = e.target
+    setForm((s) => ({ ...s, [name]: value }))
+  }
+
+  async function onSave(e) {
+    e.preventDefault()
+    setIsSaving(true)
+    setError('')
+    try {
+      await updateProfile(form)
+      navigate('/profile', { replace: true })
+    } catch (err) {
+      setError(err?.message || 'Unable to save profile')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <main className="page-shell profile-shell">
+      <section className="profile-hero panel">
+        <div>
+          <p className="eyebrow">Edit profile</p>
+          <h1>Edit your account</h1>
+          <p className="subcopy">Update your name and pickup location.</p>
+        </div>
+      </section>
+
+      <section className="profile-grid" aria-label="Edit profile form">
+        <article className="profile-card panel">
+          <form onSubmit={onSave}>
+            <label>
+              First name
+              <input name="firstName" value={form.firstName} onChange={onChange} />
+            </label>
+
+            <label>
+              Last name
+              <input name="lastName" value={form.lastName} onChange={onChange} />
+            </label>
+
+            <label>
+              Location
+              <input name="location" value={form.location} onChange={onChange} />
+            </label>
+
+            {error ? <div className="profile-empty-state">{error}</div> : null}
+
+            <div style={{ marginTop: 12 }}>
+              <button className="button button-secondary" type="button" onClick={() => navigate('/profile')} disabled={isSaving}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit" disabled={isSaving} style={{ marginLeft: 8 }}>
+                {isSaving ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </form>
+        </article>
+      </section>
+    </main>
+  )
+}

--- a/Frontend/src/routes/EditProfile.jsx
+++ b/Frontend/src/routes/EditProfile.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { fetchProfile, updateProfile } from '../services/api'
+import { fetchProfile, updateProfile, uploadProfileAvatar } from '../services/api'
 
 export default function EditProfile() {
   const navigate = useNavigate()
   const [form, setForm] = useState({ firstName: '', lastName: '', location: '' })
+  const [avatarFile, setAvatarFile] = useState(null)
+  const [avatarPreview, setAvatarPreview] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
 
@@ -20,6 +22,7 @@ export default function EditProfile() {
           lastName: user.lastName || '',
           location: user.location || '',
         })
+        setAvatarPreview(user.avatarUrl || '')
       } catch (err) {
         if (!isActive) return
         setError(err?.message || 'Unable to load profile')
@@ -36,11 +39,23 @@ export default function EditProfile() {
     setForm((s) => ({ ...s, [name]: value }))
   }
 
+  function onAvatarSelect(e) {
+    const f = e.target.files && e.target.files[0]
+    if (f) {
+      setAvatarFile(f)
+      setAvatarPreview(URL.createObjectURL(f))
+    }
+  }
+
   async function onSave(e) {
     e.preventDefault()
     setIsSaving(true)
     setError('')
     try {
+      // If an avatar file was selected, upload it first and update avatarUrl
+      if (avatarFile) {
+        await uploadProfileAvatar(avatarFile)
+      }
       await updateProfile(form)
       navigate('/profile', { replace: true })
     } catch (err) {
@@ -63,6 +78,15 @@ export default function EditProfile() {
       <section className="profile-grid" aria-label="Edit profile form">
         <article className="profile-card panel">
           <form onSubmit={onSave}>
+            <div style={{ marginBottom: 12 }}>
+              <label style={{ display: 'block', marginBottom: 6 }}>Avatar</label>
+              {avatarPreview ? (
+                <img src={avatarPreview} alt="avatar preview" style={{ width: 72, height: 72, borderRadius: 8, objectFit: 'cover', display: 'block', marginBottom: 6 }} />
+              ) : (
+                <div style={{ width: 72, height: 72, borderRadius: 8, background: '#eee', display: 'inline-block', marginBottom: 6 }} />
+              )}
+              <input type="file" accept="image/*" onChange={onAvatarSelect} />
+            </div>
             <label>
               First name
               <input name="firstName" value={form.firstName} onChange={onChange} />

--- a/Frontend/src/routes/EditProfile.jsx
+++ b/Frontend/src/routes/EditProfile.jsx
@@ -42,9 +42,58 @@ export default function EditProfile() {
   function onAvatarSelect(e) {
     const f = e.target.files && e.target.files[0]
     if (f) {
-      setAvatarFile(f)
-      setAvatarPreview(URL.createObjectURL(f))
+      // Resize image client-side for consistent avatar size and smaller upload
+      resizeImageFile(f, 512, 0.85)
+        .then((resized) => {
+          // Keep original file name if possible
+          const fileWithMeta = new File([resized], f.name, { type: resized.type })
+          setAvatarFile(fileWithMeta)
+          setAvatarPreview(URL.createObjectURL(fileWithMeta))
+        })
+        .catch(() => {
+          // Fallback to original file if resizing fails
+          setAvatarFile(f)
+          setAvatarPreview(URL.createObjectURL(f))
+        })
     }
+  }
+
+  function resizeImageFile(file, maxDim = 512, quality = 0.85) {
+    return new Promise((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        let { width, height } = img
+        if (width > maxDim || height > maxDim) {
+          const ratio = width / height
+          if (ratio > 1) {
+            width = maxDim
+            height = Math.round(maxDim / ratio)
+          } else {
+            height = maxDim
+            width = Math.round(maxDim * ratio)
+          }
+        }
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')
+        ctx.drawImage(img, 0, 0, width, height)
+        // Use webp if supported for smaller size, otherwise keep original type
+        const preferredType = 'image/webp'
+        const mime = file.type === 'image/png' ? 'image/png' : preferredType
+        canvas.toBlob(
+          (blob) => {
+            if (blob) resolve(blob)
+            else reject(new Error('Canvas toBlob produced no data'))
+          },
+          mime,
+          quality,
+        )
+      }
+      img.onerror = reject
+      // Support object URLs and DataURL
+      img.src = URL.createObjectURL(file)
+    })
   }
 
   async function onSave(e) {

--- a/Frontend/src/routes/Profile.jsx
+++ b/Frontend/src/routes/Profile.jsx
@@ -139,9 +139,11 @@ export default function Profile({ currency }) {
   return (
     <main className="page-shell profile-shell">
       <section className="profile-hero panel">
-        <div className="profile-avatar" aria-hidden="true">
-          {getInitial(displayName)}
-        </div>
+        {profile?.avatarUrl ? (
+          <img src={profile.avatarUrl} alt={`${displayName} avatar`} className="profile-avatar-img" />
+        ) : (
+          <div className="profile-avatar" aria-hidden="true">{getInitial(displayName)}</div>
+        )}
         <div className="profile-hero-copy">
           <p className="eyebrow">Your account</p>
           <h1>{displayName}</h1>

--- a/Frontend/src/routes/Profile.jsx
+++ b/Frontend/src/routes/Profile.jsx
@@ -149,6 +149,11 @@ export default function Profile({ currency }) {
             Your profile is powered by the backend and keeps your listings, location, and saved payment methods in one place.
           </p>
         </div>
+        <div style={{ marginLeft: 'auto' }}>
+          <button className="button button-secondary" type="button" onClick={() => navigate('/profile/edit')}>
+            Edit profile
+          </button>
+        </div>
         <div className="profile-hero-meta">
           <div>
             <span className="profile-meta-label">Email</span>

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -71,3 +71,10 @@ export async function createItem(itemData) {
 export async function fetchProfile() {
   return apiRequest('/profile')
 }
+
+export async function updateProfile(data) {
+  return apiRequest('/profile', {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -78,3 +78,12 @@ export async function updateProfile(data) {
     body: JSON.stringify(data),
   })
 }
+
+export async function uploadProfileAvatar(file) {
+  const fd = new FormData()
+  fd.append('image', file)
+  return apiRequest('/profile/avatar', {
+    method: 'POST',
+    body: fd,
+  })
+}

--- a/app.py
+++ b/app.py
@@ -521,6 +521,48 @@ def upload_profile_avatar():
     return jsonify({'message': 'Avatar uploaded successfully.', 'filename': stored_filename, 'url': file_url}), 201
 
 
+@app.delete('/api/profile/avatar')
+def delete_profile_avatar():
+    """Remove a user's avatar file and clear the avatar field from their profile."""
+    auth_header = request.headers.get('Authorization', '')
+    if not auth_header.startswith('Bearer '):
+        return json_error('Missing bearer token.', 401)
+
+    token = auth_header.removeprefix('Bearer ').strip()
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
+    except jwt.PyJWTError:
+        return json_error('Invalid or expired token.', 401)
+
+    user_id = parse_object_id(payload.get('sub'))
+    if not user_id:
+        return json_error('Invalid or expired token.', 401)
+
+    user_doc = users.find_one({'_id': user_id})
+    if not user_doc:
+        return json_error('Invalid or expired token.', 401)
+
+    avatar_val = user_doc.get('avatar')
+    if not avatar_val:
+        return json_error('No avatar to delete.', 400)
+
+    # Attempt to delete the file from disk but don't fail if it does not exist.
+    try:
+        file_path = UPLOAD_FOLDER / str(avatar_val)
+        if file_path.exists():
+            file_path.unlink()
+    except Exception:
+        # Log and continue — we'll still clear the DB reference.
+        pass
+
+    try:
+        users.update_one({'_id': user_id}, {'$unset': {'avatar': ''}, '$set': {'updatedAt': datetime.now(timezone.utc)}})
+    except Exception as exc:
+        return json_error(f'Failed to clear avatar from profile: {str(exc)}', 500)
+
+    return jsonify({'message': 'Avatar removed.'})
+
+
 @app.post('/api/auth/signup')
 def signup():
     data = request.get_json(silent=True) or {}

--- a/app.py
+++ b/app.py
@@ -609,6 +609,59 @@ def profile_summary():
     })
 
 
+@app.put('/api/profile')
+def update_profile():
+    """Update basic profile fields for the current authenticated user.
+
+    Accepts JSON body with optional keys: firstName, lastName, location
+    Returns the updated user payload on success.
+    """
+    auth_header = request.headers.get('Authorization', '')
+    if not auth_header.startswith('Bearer '):
+        return json_error('Missing bearer token.', 401)
+
+    token = auth_header.removeprefix('Bearer ').strip()
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
+    except jwt.PyJWTError:
+        return json_error('Invalid or expired token.', 401)
+
+    user_id = parse_object_id(payload.get('sub'))
+    if not user_id:
+        return json_error('Invalid or expired token.', 401)
+
+    user_doc = users.find_one({'_id': user_id})
+    if not user_doc:
+        return json_error('Invalid or expired token.', 401)
+
+    data = request.get_json(silent=True) or {}
+    updates = {}
+    if 'firstName' in data:
+        fn = str(data.get('firstName', '')).strip()
+        if fn:
+            updates['firstName'] = fn
+    if 'lastName' in data:
+        ln = str(data.get('lastName', '')).strip()
+        if ln:
+            updates['lastName'] = ln
+    if 'location' in data:
+        loc = str(data.get('location', '')).strip()
+        updates['location'] = loc
+
+    if not updates:
+        return json_error('No profile fields provided to update.', 400)
+
+    updates['updatedAt'] = datetime.now(timezone.utc)
+
+    try:
+        users.update_one({'_id': user_id}, {'$set': updates})
+    except Exception as exc:
+        return json_error(f'Failed to update profile: {str(exc)}', 500)
+
+    updated_user_doc = users.find_one({'_id': user_id})
+    return jsonify({'user': build_user_payload(updated_user_doc)})
+
+
 @app.get('/api/items')
 def get_items():
     """Fetch all marketplace items with pagination and filtering."""

--- a/app.py
+++ b/app.py
@@ -327,6 +327,7 @@ def build_user_payload(user_doc):
         'email': user_doc['email'],
         'isVerified': user_doc.get('isVerified', False),
         'location': user_doc.get('location', ''),
+        'avatar': user_doc.get('avatar', ''),
         'paymentMethods': payment_methods,
     }
 
@@ -464,6 +465,62 @@ def upload_image():
     }), 201
 
 
+@app.post('/api/profile/avatar')
+def upload_profile_avatar():
+    """Upload and attach an avatar image to the authenticated user's profile."""
+    auth_header = request.headers.get('Authorization', '')
+    if not auth_header.startswith('Bearer '):
+        return json_error('Missing bearer token.', 401)
+
+    token = auth_header.removeprefix('Bearer ').strip()
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
+    except jwt.PyJWTError:
+        return json_error('Invalid or expired token.', 401)
+
+    user_id = parse_object_id(payload.get('sub'))
+    if not user_id:
+        return json_error('Invalid or expired token.', 401)
+
+    user_doc = users.find_one({'_id': user_id})
+    if not user_doc:
+        return json_error('Invalid or expired token.', 401)
+
+    uploaded_file = request.files.get('image') or request.files.get('avatar')
+    if not uploaded_file or not uploaded_file.filename:
+        return json_error('An image file is required.', 400)
+
+    safe_filename = secure_filename(uploaded_file.filename)
+    if not safe_filename:
+        return json_error('The uploaded filename is not valid.', 400)
+
+    file_extension = os.path.splitext(safe_filename)[1].lower()
+    if file_extension not in ALLOWED_IMAGE_EXTENSIONS:
+        return json_error('Unsupported image format.', 400)
+
+    if uploaded_file.mimetype not in ALLOWED_IMAGE_MIMETYPES:
+        return json_error('Only image uploads are allowed.', 400)
+
+    if (
+        request.content_length
+        and request.content_length > MAX_IMAGE_UPLOAD_BYTES
+    ):
+        return json_error('Image must be smaller than 5 MB.', 413)
+
+    stored_filename = f"{uuid4().hex}-{safe_filename}"
+    stored_path = UPLOAD_FOLDER / stored_filename
+    uploaded_file.save(stored_path)
+
+    file_url = f"{request.host_url.rstrip('/')}/api/uploads/{stored_filename}"
+
+    try:
+        users.update_one({'_id': user_id}, {'$set': {'avatar': stored_filename, 'updatedAt': datetime.now(timezone.utc)}})
+    except Exception as exc:
+        return json_error(f'Failed to attach avatar to profile: {str(exc)}', 500)
+
+    return jsonify({'message': 'Avatar uploaded successfully.', 'filename': stored_filename, 'url': file_url}), 201
+
+
 @app.post('/api/auth/signup')
 def signup():
     data = request.get_json(silent=True) or {}
@@ -595,6 +652,17 @@ def profile_summary():
     activity = fetch_user_activity(user_id)
     user_payload = build_user_payload(user_doc)
     user_payload['paymentMethods'] = get_safe_payment_methods(user_doc)
+
+    # Expose avatarUrl as an absolute URL when available so frontend can load it.
+    avatar_val = user_doc.get('avatar') or user_doc.get('avatarUrl')
+    if avatar_val:
+        if isinstance(avatar_val, str) and avatar_val.strip():
+            if re.match(r'^https?://', avatar_val):
+                user_payload['avatarUrl'] = avatar_val
+            else:
+                user_payload['avatarUrl'] = f"{request.host_url.rstrip('/')}/api/uploads/{str(avatar_val).lstrip('/')}"
+    else:
+        user_payload['avatarUrl'] = ''
 
     return jsonify({
         'user': user_payload,

--- a/docs/ProfileTesting.md
+++ b/docs/ProfileTesting.md
@@ -1,0 +1,25 @@
+# Profile Testing Notes
+
+## What to verify
+- Signed-in users stay in the authenticated nav when opening Profile.
+- Clicking Home while signed in keeps users in the dashboard experience.
+- Profile loads the current signed-in user's details.
+- Edit Profile saves name and location.
+- Avatar uploads are resized client-side and displayed as a clean avatar.
+- Avatar delete removes the current avatar.
+
+## Local test steps
+1. Start backend:
+   ```bash
+   /Users/gayatribhandari/Documents/campusMarketPlace/.venv/bin/python app.py
+   ```
+2. Start frontend:
+   ```bash
+   cd Frontend && npm run dev
+   ```
+3. Sign in, open Profile, upload a square image, and confirm it shows as a fixed-size avatar.
+4. Click Home while signed in and confirm you remain in the dashboard.
+
+## Test data
+- Email format: `@office.uc.ac.kr`
+- Password must include uppercase, lowercase, number, and special character.

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -1,0 +1,51 @@
+import os
+import io
+import json
+import pytest
+from pathlib import Path
+
+# These tests require a running MongoDB and the Flask app to be configured
+# with a test database. Set environment variable TEST_MONGODB_URI before
+# running to avoid touching production data.
+
+TEST_DB_URI = os.getenv('TEST_MONGODB_URI')
+
+pytestmark = pytest.mark.skipif(
+    not TEST_DB_URI,
+    reason='Set TEST_MONGODB_URI to run integration tests against a test database',
+)
+
+
+def test_signup_login_and_avatar_upload(client):
+    # This test assumes the pytest fixture `client` is configured to provide
+    # a Flask test client against the application using the test DB.
+    email = 'itest@example.com'
+    password = 'Test1234!'
+
+    # Signup
+    resp = client.post('/api/auth/signup', json={'firstName': 'IT', 'lastName': 'User', 'email': email, 'password': password})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert 'token' in data
+    token = data['token']
+
+    # Upload avatar using an in-memory small PNG
+    img = io.BytesIO()
+    # A tiny 1x1 PNG binary
+    img.write(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0bIDAT\x08\xd7c``\x00\x00\x00\x04\x00\x01\x0d\n\x2dB\x00\x00\x00\x00IEND\xaeB`\x82')
+    img.seek(0)
+
+    rv = client.post('/api/profile/avatar', data={'image': (img, 'small.png')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
+    assert rv.status_code == 201
+    rv_data = rv.get_json()
+    assert 'url' in rv_data
+
+    # Delete avatar
+    rv2 = client.delete('/api/profile/avatar', headers={'Authorization': f'Bearer {token}'})
+    assert rv2.status_code == 200
+
+
+# Note: To run these tests locally, create a conftest.py fixture that creates
+# a Flask test client and configures the app to use TEST_MONGODB_URI. This
+# file intentionally leaves those details out to avoid assumptions about your
+# CI/test configuration.


### PR DESCRIPTION
## Summary
- Added a complete signed-in profile experience with an editable profile page.
- Implemented avatar upload support with client-side resizing so avatars stay clean and consistent.
- Updated navigation so signed-in users stay in the authenticated experience instead of returning to the public homepage.

## Linked Issue
Closes #81 

## Changes
- Added `Profile` and `EditProfile` routes in the frontend.
- Added profile update support in the backend with `PUT /api/profile`.
- Added avatar upload and delete endpoints for signed-in users.
- Added client-side image resizing before upload.
- Styled avatars as fixed-size, professional thumbnails.
- Updated navbar behavior for signed-in users.
- Removed the Browse link from the home nav while signed in.
- Added profile testing notes and a test scaffold.

## How Tested (required)
- [x] Ran locally: `/Users/gayatribhandari/Documents/campusMarketPlace/.venv/bin/python app.py`
- [x] Ran locally: `cd Frontend && npm run dev`
- [x] API verification:
  - signup
  - login
  - `PUT /api/profile`
  - `GET /api/profile`
- [x] Local backend verification showed updated profile data returning correctly.

## Screenshots / Demo (if user-facing)
- Before: public-style navigation and no avatar upload support
- After: signed-in profile page with avatar upload, edit form, and consistent authenticated navigation
- Demo link (optional): none

## Risk / Rollback
- Risk:
  - Avatar upload adds file storage and image handling paths.
  - Profile endpoints depend on authenticated requests.
- Rollback plan:
  - Revert the profile/avatar-related commits on `for-profiles` if needed.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [x] I updated docs if needed (`/docs`)
- [x] I added/updated tests if relevant