### PR TITLE
Bugs

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -90,12 +90,42 @@ input {
   padding-right: 4.5rem;
 }
 
+/* Allow horizontal scrolling on very small viewports so nav doesn't wrap awkwardly */
+.nav-links {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* Currency hamburger in the top-right corner */
 .currency-hamburger-wrapper {
   position: absolute;
   top: 12px;
   right: 12px;
   z-index: 40;
+}
+
+@media (max-width: 640px) {
+  .brand-row {
+    padding: 0.6rem 0.8rem;
+  }
+
+  .nav-links {
+    gap: 0.45rem;
+    padding-right: 1rem;
+  }
+
+  .nav-links a,
+  .nav-pill,
+  .nav-signout {
+    padding: 0.45rem 0.6rem;
+    font-size: 0.92rem;
+    min-width: auto;
+  }
+
+  .currency-hamburger-wrapper {
+    right: 8px;
+    top: 8px;
+  }
 }
 
 .currency-hamburger {

--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -90,42 +90,12 @@ input {
   padding-right: 4.5rem;
 }
 
-/* Allow horizontal scrolling on very small viewports so nav doesn't wrap awkwardly */
-.nav-links {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 /* Currency hamburger in the top-right corner */
 .currency-hamburger-wrapper {
   position: absolute;
   top: 12px;
   right: 12px;
   z-index: 40;
-}
-
-@media (max-width: 640px) {
-  .brand-row {
-    padding: 0.6rem 0.8rem;
-  }
-
-  .nav-links {
-    gap: 0.45rem;
-    padding-right: 1rem;
-  }
-
-  .nav-links a,
-  .nav-pill,
-  .nav-signout {
-    padding: 0.45rem 0.6rem;
-    font-size: 0.92rem;
-    min-width: auto;
-  }
-
-  .currency-hamburger-wrapper {
-    right: 8px;
-    top: 8px;
-  }
 }
 
 .currency-hamburger {
@@ -253,6 +223,42 @@ input {
 .nav-signout:hover {
   color: var(--text);
   border-color: rgba(77, 195, 255, 0.55);
+}
+
+/* Responsive tweaks for small screens to keep profile/button layout tidy */
+@media (max-width: 640px) {
+  .brand-row {
+    padding: 0.75rem 1rem;
+  }
+
+  .nav-links {
+    padding-right: 1rem;
+    gap: 0.45rem;
+    justify-content: flex-end;
+  }
+
+  .nav-links .nav-pill,
+  .nav-links .nav-signout,
+  .nav-links a {
+    padding: 0.45rem 0.6rem;
+    min-width: 0;
+    font-size: 0.92rem;
+  }
+
+  .currency-hamburger-wrapper {
+    right: 8px;
+    top: 8px;
+  }
+
+  .currency-hamburger {
+    width: 34px;
+    height: 30px;
+    padding: 6px;
+  }
+
+  .brand {
+    font-size: 0.98rem;
+  }
 }
 
 .profile-shell {

--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -1225,6 +1225,20 @@ h1 {
   color: var(--muted);
 }
 
+.thread-unread-badge {
+  display: inline-grid;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 8px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #03111c;
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
 .thread-item p {
   margin: 0.35rem 0 0;
   font-weight: 700;

--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -141,6 +141,22 @@ input {
   box-shadow: var(--shadow);
 }
 
+.search-menu {
+  min-width: 160px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(3,11,19,0.98);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 56px;
+  z-index: 45;
+  box-shadow: var(--shadow);
+}
+
 .menu-section {
   display: flex;
   flex-direction: column;

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -17,6 +17,9 @@ export default function Navbar({
   const showAuthNav = isDashboard || isAuthenticated
   const [showSignOutModal, setShowSignOutModal] = useState(false)
   const [currencyMenuOpen, setCurrencyMenuOpen] = useState(false)
+  const [searchMenuOpen, setSearchMenuOpen] = useState(false)
+
+  const STORIES = ['Engineering', 'Dorm Deals', 'Books']
 
   function handleHome() {
     if (isDashboard) {
@@ -40,11 +43,8 @@ export default function Navbar({
   }
 
   function handleSearch() {
-    const composerButton = document.querySelector('.composer-input')
-    if (composerButton instanceof HTMLElement) {
-      composerButton.focus()
-      composerButton.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    }
+    // Toggle the search/story menu instead of focusing the composer directly
+    setSearchMenuOpen((s) => !s)
   }
 
   function handleSignOut() {
@@ -138,6 +138,23 @@ export default function Navbar({
                 <button className="nav-pill" type="button" onClick={handleSearch}>
                   Search
                 </button>
+                {searchMenuOpen && (
+                  <div className="search-menu" role="menu" aria-label="Quick categories">
+                    {STORIES.map((s) => (
+                      <button
+                        key={s}
+                        type="button"
+                        className="currency-menu-item"
+                        onClick={() => {
+                          setSearchMenuOpen(false)
+                          navigate(`/browse?category=${encodeURIComponent(s)}`)
+                        }}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
+                )}
                 {isAuthenticated && (
                   <button className="nav-pill" type="button" onClick={handleProfile}>
                     Profile

--- a/Frontend/src/constants/categories.js
+++ b/Frontend/src/constants/categories.js
@@ -1,12 +1,12 @@
 export const CATEGORIES = [
-  'Textbooks',
-  'Electronics',
-  'Furniture',
-  'Clothing',
-  'Sports',
   'Books',
+  'Furniture',
+  'Tools',
+  'Notes',
+  'Clothing',
+  'Dorm Deals',
+  'Electronics',
   'Supplies',
-  'Services',
   'Other',
 ]
 

--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiRequest, createItem, fetchItems } from '../services/api'
+import { CATEGORIES } from '../constants/categories'
 import { convertDisplayPriceToUsd, formatPriceFromUsd, getPriceInputMeta } from '../services/currency'
 
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
@@ -340,14 +341,19 @@ export default function Dashboard({ currency }) {
                 />
                 {formErrors.price && <p className="composer-feedback is-error">{formErrors.price}</p>}
 
-                <input
+                <select
                   name="category"
-                  type="text"
-                  placeholder="Category"
                   value={formData.category}
                   onChange={handleFormChange}
                   className="composer-text-input"
-                />
+                >
+                  <option value="">Select a category</option>
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
                 {formErrors.category && <p className="composer-feedback is-error">{formErrors.category}</p>}
 
                 <select

--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -438,13 +438,7 @@ export default function Dashboard({ currency }) {
             </form>
           </section>
 
-          <section className="stories-row" aria-label="Stories">
-            {STORIES.map((story) => (
-              <article className="story-card" key={story}>
-                <span>{story}</span>
-              </article>
-            ))}
-          </section>
+          {/* Stories moved into the Search menu in the navbar */}
 
           <section className="feed-post-list" aria-label="Marketplace feed posts">
             {loading ? (

--- a/Frontend/src/routes/Messages.jsx
+++ b/Frontend/src/routes/Messages.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { fetchMessageThreads, fetchThreadMessages, openMessageThread, sendThreadMessage } from '../services/api'
+import { fetchMessageThreads, fetchThreadMessages, openMessageThread, sendThreadMessage, markThreadRead } from '../services/api'
 
 const POLL_INTERVAL_MS = 4000
 
@@ -88,6 +88,16 @@ export default function Messages() {
             return
           }
           setMessages(Array.isArray(threadMessages?.messages) ? threadMessages.messages : [])
+          // mark as read for the current user so unread count updates
+          try {
+            await markThreadRead(nextThread._id)
+            const updatedList = await fetchMessageThreads()
+            if (isActive) {
+              setThreads(Array.isArray(updatedList?.threads) ? updatedList.threads : [])
+            }
+          } catch (e) {
+            // non-fatal
+          }
         }
       } catch (err) {
         if (isActive) {
@@ -157,6 +167,17 @@ export default function Messages() {
       const threadData = await fetchThreadMessages(threadId)
       setActiveThread(threadData?.thread || null)
       setMessages(Array.isArray(threadData?.messages) ? threadData.messages : [])
+      // mark this thread read now that the user actively opened it
+      try {
+        const readResp = await markThreadRead(threadId)
+        if (readResp?.thread) {
+          setActiveThread(readResp.thread)
+        }
+        const threadList = await fetchMessageThreads()
+        setThreads(Array.isArray(threadList?.threads) ? threadList.threads : [])
+      } catch (e) {
+        // ignore read-mark failures
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to open the conversation.')
     }
@@ -213,7 +234,12 @@ export default function Messages() {
                 >
                   <div className="thread-item-top">
                     <strong>{thread.other_user_name || 'Conversation'}</strong>
-                    <span>{formatTime(thread.latestMessageAt || thread.updatedAt)}</span>
+                    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+                      <span>{formatTime(thread.latestMessageAt || thread.updatedAt)}</span>
+                      {thread.unreadCount > 0 ? (
+                        <span className="thread-unread-badge" aria-label={`${thread.unreadCount} unread messages`}>{thread.unreadCount}</span>
+                      ) : null}
+                    </div>
                   </div>
                   <p>{thread.itemTitle || 'Listing conversation'}</p>
                   <small>{thread.latestMessage || 'Tap to open this chat.'}</small>

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -102,6 +102,12 @@ export async function sendThreadMessage(threadId, body) {
   })
 }
 
+export async function markThreadRead(threadId) {
+  return apiRequest(`/messages/threads/${threadId}/read`, {
+    method: 'POST',
+  })
+}
+
 export async function uploadProfileAvatar(file) {
   const fd = new FormData()
   fd.append('image', file)

--- a/app.py
+++ b/app.py
@@ -575,6 +575,37 @@ def build_message_thread_payload(thread_doc, current_user_id=None):
     payload['itemImage'] = thread_doc.get('item_image', '')
     payload['latestMessage'] = thread_doc.get('latest_message', '')
     payload['latestMessageAt'] = payload.pop('latest_message_at', None)
+    # Compute unread count for the current user (messages with createdAt > last_read)
+    try:
+        thread_oid = thread_doc.get('_id')
+        # thread_doc may have stringified _id after serialize; attempt to parse
+        if isinstance(thread_oid, str):
+            thread_oid = parse_object_id(thread_oid)
+    except Exception:
+        thread_oid = None
+
+    unread_count = 0
+    if current_user_id and thread_oid:
+        try:
+            last_read_map = thread_doc.get('last_read', {}) or {}
+            last_read_str = last_read_map.get(str(current_user_id))
+            if last_read_str:
+                try:
+                    last_read_dt = datetime.fromisoformat(last_read_str.replace('Z', '+00:00'))
+                except Exception:
+                    last_read_dt = None
+            else:
+                last_read_dt = None
+
+            query = {'thread_id': thread_oid}
+            if last_read_dt:
+                query['createdAt'] = {'$gt': last_read_dt}
+
+            unread_count = message_messages.count_documents(query)
+        except Exception:
+            unread_count = 0
+
+    payload['unreadCount'] = int(unread_count)
     return payload
 
 
@@ -1008,9 +1039,17 @@ def open_message_thread():
             'latest_message_at': None,
             'createdAt': now,
             'updatedAt': now,
+            'last_read': {},
         }
         inserted = message_threads.insert_one(thread_doc)
         thread_doc['_id'] = inserted.inserted_id
+    # Mark the opener as having last-read at this moment so messages prior are not treated as unread for them
+    try:
+        message_threads.update_one({'_id': thread_doc['_id']}, {'$set': {f'last_read.{str(user_id)}': datetime.now(timezone.utc).isoformat(), 'updatedAt': datetime.now(timezone.utc)}})
+        # refresh thread_doc
+        thread_doc = message_threads.find_one({'_id': thread_doc['_id']})
+    except Exception:
+        pass
 
     return jsonify({
         'thread': build_message_thread_payload(thread_doc, current_user_id=user_id),
@@ -1037,6 +1076,34 @@ def get_message_thread(thread_id):
     return jsonify({
         'thread': build_message_thread_payload(thread_doc, current_user_id=user_id),
     })
+
+
+@app.post('/api/messages/threads/<thread_id>/read')
+def mark_thread_read(thread_id):
+    """Mark the current user as having read the conversation up to now."""
+    user_id, _user_doc, auth_error = get_current_user_from_request()
+    if auth_error:
+        return auth_error
+
+    thread_oid = parse_object_id(thread_id)
+    if not thread_oid:
+        return json_error('Invalid thread id.', 400)
+
+    thread_doc = message_threads.find_one({'_id': thread_oid})
+    if not thread_doc:
+        return json_error('Conversation not found.', 404)
+
+    if user_id not in thread_doc.get('participants', []):
+        return json_error('You do not have access to this conversation.', 403)
+
+    now = datetime.now(timezone.utc)
+    try:
+        message_threads.update_one({'_id': thread_oid}, {'$set': {f'last_read.{str(user_id)}': now.isoformat(), 'updatedAt': now}})
+    except Exception as exc:
+        return json_error(f'Failed to mark thread read: {str(exc)}', 500)
+
+    thread_doc = message_threads.find_one({'_id': thread_oid})
+    return jsonify({'thread': build_message_thread_payload(thread_doc, current_user_id=user_id)})
 
 
 @app.get('/api/messages/threads/<thread_id>/messages')
@@ -1118,6 +1185,8 @@ def send_message(thread_id):
             }
         },
     )
+
+    # Do not modify recipient last_read here; recipient will see this message as unread until they mark as read or open the thread.
 
     return jsonify({
         'message': serialize_message_document(message_doc),


### PR DESCRIPTION
##Summary

- Move dashboard “stories” quick-links into a small quick-links menu attached to the Search button in the [Navbar] for a cleaner composer layout.
- Replace free-text category input in the composer with a canonical [select] (Books, Furniture, Tools, Notes, Clothing, Dorm Deals, Electronics, Supplies, Other).
- Add message unread/read support (backend mark-read endpoint + frontend [markThreadRead](call), badge styling, and responsive navbar/profile fixes for small screens.

##Linked Issue
Closes #87 

##Changes
- Backend
[app.py]: add POST /api/messages/threads/<thread_id>/read to mark a thread read and include [unreadCount]in thread payload.
- Frontend
[api.js]: add [markThreadRead(threadId)] helper.
[Messages.jsx]: call [markThreadRead()] when opening a thread; show [unreadCount] badge in thread list.
[Dashboard.jsx]: replace stories row with composer-only UI and replace category text input with [select] using canonical categories.
[Navbar.jsx]: add Search toggle menu with quick-links (Engineering, Dorm Deals, Books); toggle behavior for Search replaced composer-focus behavior.
[categories.js]: updated canonical categories list.
[global.css]: add [.thread-unread-badge], .search-menu styling, and responsive navbar tweaks to fix profile/button overlap on mobile.

##How Tested (required)
 - [x] Ran locally: (python3 -m py_compile app.py)
- [x] CI checks

##Screenshots / Demo (if user-facing)

1) Before:
- Composer showed a stories row under the post box (cluttered on mobile).
- 
2)After:
- Composer has category [select], no inline stories row.
- Click Search in the navbar → small quick-links menu appears (Engineering, Dorm Deals, Books) → navigates to [/browse?category=...].
- Messages: unread badge appears in thread list and clears when opening a thread.

##Risk / Rollback
- Risk:
Small UX change (stories moved to Navbar) may confuse users who expect the row in the feed.
Frontend now calls the new mark-read endpoint; if backend not deployed or auth is misconfigured, marking read will silently fail (handled as non-fatal in UI).
Category normalization: existing items with free-text categories may not match the new canonical categories until normalized.
- Rollback plan:
Revert the bugs branch commits (or reset branch) and open a PR reverting the changes.
If only the frontend needs rollback quickly, revert the frontend commits on bugs and re-push.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant