### PR TITLE
Fix dashboard image rendering

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -1154,9 +1154,28 @@ h1 {
   margin-top: 0.8rem;
   border-radius: 12px;
   min-height: 220px;
+  overflow: hidden;
   background:
     radial-gradient(circle at 75% 20%, rgba(255, 255, 255, 0.2), transparent 30%),
     linear-gradient(135deg, rgba(77, 195, 255, 0.42), rgba(27, 166, 238, 0.08));
+}
+
+.post-image img,
+.post-image-fallback {
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  display: block;
+  object-fit: cover;
+}
+
+.post-image-fallback {
+  display: grid;
+  place-items: center;
+  color: #03111c;
+  font-size: 2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--accent), #8be5ff);
 }
 
 .post-body {

--- a/Frontend/src/routes/Dashboard.jsx
+++ b/Frontend/src/routes/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { apiRequest, createItem, fetchItems } from '../services/api'
 import { CATEGORIES } from '../constants/categories'
 import { convertDisplayPriceToUsd, formatPriceFromUsd, getPriceInputMeta } from '../services/currency'
+import { API_ORIGIN } from '../services/api'
 
 const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 5
@@ -27,6 +28,41 @@ const STORIES = [
   'Tech',
   'Furniture',
 ]
+
+function getPrimaryImageValue(item) {
+  if (item?.image) {
+    if (typeof item.image === 'string') {
+      return item.image
+    }
+    if (typeof item.image === 'object' && item.image.url) {
+      return item.image.url
+    }
+  }
+
+  if (Array.isArray(item?.images) && item.images.length > 0) {
+    const first = item.images[0]
+    if (typeof first === 'string') {
+      return first
+    }
+    if (first && typeof first === 'object' && first.url) {
+      return first.url
+    }
+  }
+
+  return ''
+}
+
+function resolveImageUrl(imageUrl) {
+  if (!imageUrl) {
+    return ''
+  }
+
+  if (/^https?:\/\//i.test(imageUrl) || imageUrl.startsWith('data:') || imageUrl.startsWith('blob:')) {
+    return imageUrl
+  }
+
+  return new URL(imageUrl.replace(/^\/+/, ''), `${API_ORIGIN}/`).href
+}
 
 export default function Dashboard({ currency }) {
   const navigate = useNavigate()
@@ -136,6 +172,10 @@ export default function Dashboard({ currency }) {
 
   function openMessageThread(itemId) {
     navigate(`/messages?item=${encodeURIComponent(itemId)}`)
+  }
+
+  function getItemImageSrc(item) {
+    return resolveImageUrl(getPrimaryImageValue(item))
   }
 
   function removeUploadedImage(indexToRemove) {
@@ -465,7 +505,19 @@ export default function Dashboard({ currency }) {
                       <p>{item.location || 'Campus'}</p>
                     </div>
                   </header>
-                  <div className="post-image" aria-hidden="true" />
+                  <div className="post-image">
+                    {getItemImageSrc(item) ? (
+                      <img
+                        src={getItemImageSrc(item)}
+                        alt={item.title ? `${item.title} listing` : 'Marketplace listing'}
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="post-image-fallback" aria-hidden="true">
+                        <span>{(item.category || 'Item').slice(0, 1).toUpperCase()}</span>
+                      </div>
+                    )}
+                  </div>
                   <div className="post-body">
                     <div className="post-price">{formatPriceFromUsd(item.price, currency)}</div>
                     <h2>{item.title}</h2>


### PR DESCRIPTION

## Summary

- Render listing images in the dashboard feed cards so new posts display their uploaded photo.
- Resolve relative upload URLs against the API origin so links load in deployed environments.
- Add CSS rules to make .post-image show the image with object-fit: cover and provide a fallback avatar tile.
- Fix a missing closing brace in global.css that broke stylesheet parsing.

## Linked Issue
Closes #68
 Relates to #68 

## Changes
- Dashboard.jsx : add getPrimaryImageValue, resolveImageUrl, getItemImageSrc and render <img> inside the dashboard post card.
- global.css : add .post-image img / .post-image-fallback rules and close a missing brace.
- Commit: d3a50cb (pushed to bugs)

## How Tested (required)
- [x] Ran locally: ( Backend: export FLASK_ENV=development
                                               python app.py
                              Fronted: cd Frontend
                                             npm install
                                             npm run dev)
- [x] CI checks: 

## Screenshots / Demo (if user-facing)
- Before: 
<img width="739" height="549" alt="Screenshot 2026-05-20 at 9 53 28 AM" src="https://github.com/user-attachments/assets/3b670b3a-beb3-428e-82a6-da307ef5101c" />

## Risk / Rollback
- Risk: Minor UI change to feed cards; CSS selector scope is narrow. Possible visual differences on edge-case aspect ratios.
- Rollback plan: Revert commit d3a50cb or restore main-branch state.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
