### PR TITLE
fix: persist auth session using localStorage instead of sessionStorage

### DIFF
--- a/Frontend/src/services/auth.js
+++ b/Frontend/src/services/auth.js
@@ -6,7 +6,7 @@ function getSessionStorage() {
     return null
   }
 
-  return window.sessionStorage
+  return window.localStorage
 }
 
 export function readAuthSession() {


### PR DESCRIPTION
<!--
STUDENT NOTE: This PR template is how you make your work reviewable.
Fill it in like you want a teammate to understand it in 60 seconds.
-->

## Summary
- Changed auth session storage from `sessionStorage` to `localStorage` to persist user authentication across browser sessions
- Users will now remain logged in even after closing and reopening the browser
- Improves user experience by eliminating unnecessary re-authentication


## Linked Issue
<!-- REQUIRED: link the Issue that planned this work -->
Relates to #118 


## Changes
<!-- What did you actually do? Keep it concrete. -->
- Modified [Frontend/src/services/auth.js](Frontend/src/services/auth.js) to use `window.localStorage` instead of `window.sessionStorage` for session persistence
- Updated `getSessionStorage()` function on line 9 to return localStorage


## How Tested (required)
<!-- “It works on my machine” is not a test. Write the commands or steps. -->
- [ ] Ran locally: 
  - `npm run dev` in Frontend/
  - Logged in with test account
  - Closed browser completely
  - Reopened browser and verified user remains logged in
- [ ] Tests: Manual testing (verify automatic re-authentication works)



## Screenshots / Demo (if user-facing)
<!-- If the UI changed, prove it. -->
- Before: User session cleared on browser close, requiring re-login
- After: User session persists across browser restarts
- Demo link (optional): N/A

## Risk / Rollback
<!-- What might break? How do we undo quickly? -->
- Risk: Users' localStorage will retain auth tokens even if they close the browser, which could be a security concern on shared devices
- Rollback plan: Revert single-line change back to `sessionStorage` in auth.js if security concerns arise


## Checklist
- [ ] I linked an Issue
- [ ] I used a branch (not direct to `main`)
- [ ] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant
