### PR TITLE
Hide categories toggle

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -412,6 +412,7 @@ html.dark .tagline { color: #f2fbf9; font-weight: 600; letter-spacing: 0; }
 html.dark .subcopy { color: #dce9e7; font-weight: 500; letter-spacing: 0; }
 
 .feature-list, .category-chip-row { display: flex; flex-wrap: wrap; gap: 0.7rem; }
+.category-options-wrap { display: flex; align-items: flex-start; flex-wrap: wrap; gap: 0.7rem; margin: 0.85rem 0 0.7rem; }
 .hero-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; align-items: stretch; }
 .feature-list { margin: 1.5rem 0; }
 .marketplace-hero { display: grid; gap: 1rem; }
@@ -434,6 +435,7 @@ html.dark .feature-pill, html.dark .category-chip, html.dark .badge, html.dark .
 .button:disabled, .composer-submit:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
 .button-primary, .composer-submit { color: #fff; font-weight: 800; background: linear-gradient(135deg, var(--primary) 0%, #17894f 100%); box-shadow: 0 16px 32px rgba(12, 109, 63, 0.24); }
 .button-primary:hover, .composer-submit:hover { box-shadow: 0 18px 38px rgba(12, 109, 63, 0.3); }
+.category-toggle { justify-self: start; min-height: 0; padding: 0.5rem 0.8rem; font-size: 0.84rem; line-height: 1; font-weight: 800; gap: 0.35rem; }
 .hero-actions .button:hover { border-color: rgba(12, 109, 63, 0.22); box-shadow: 0 18px 38px rgba(12, 109, 63, 0.28); }
 .hero-actions .home-cta-primary { color: #111827; }
 .hero-actions .home-cta-primary.button-primary {
@@ -656,6 +658,7 @@ html.dark .password-rules {
 }
 
 .category-chip-row { margin-top: 0.4rem; }
+.category-options-wrap .category-chip-row { margin-top: 0; }
 .category-chip { border-color: var(--border); background: rgba(255, 255, 255, 0.92); }
 .category-chip.is-active { box-shadow: 0 10px 24px rgba(15, 123, 69, 0.18); }
 .browse-section { width: 100%; margin-top: 1.3rem; display: grid; gap: 1.15rem; }

--- a/Frontend/src/routes/Browse.jsx
+++ b/Frontend/src/routes/Browse.jsx
@@ -14,6 +14,7 @@ export default function Browse({ currency, language = 'en' }) {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
   const [reloadToken, setReloadToken] = useState(0)
+  const [showCategories, setShowCategories] = useState(false)
 
   const currentPage = Math.max(1, parseInt(searchParams.get('page') || '1', 10))
   const currentCategory = searchParams.get('category') || ''
@@ -86,24 +87,38 @@ export default function Browse({ currency, language = 'en' }) {
         <p className="eyebrow">{t(language, 'browse.eyebrow')}</p>
         <h1>{t(language, 'browse.title')}</h1>
         <p className="subcopy">{t(language, 'browse.subcopy')}</p>
-        <div className="category-chip-row" aria-label="Quick category filters">
+        <div className="category-options-wrap">
           <button
             type="button"
-            className={`category-chip ${!currentCategory ? 'is-active' : ''}`}
-            onClick={() => handleCategoryChange('')}
+            className="button button-secondary category-toggle"
+            aria-expanded={showCategories}
+            aria-controls="browse-category-options"
+            onClick={() => setShowCategories((current) => !current)}
           >
-            {t(language, 'browse.all')}
+            Show options <span aria-hidden="true">{showCategories ? '→' : '●'}</span>
           </button>
-          {CATEGORIES.map((category) => (
+
+          {showCategories && (
+            <div id="browse-category-options" className="category-chip-row" aria-label="Quick category filters">
             <button
-              key={category}
               type="button"
-              className={`category-chip ${currentCategory === category ? 'is-active' : ''}`}
-              onClick={() => handleCategoryChange(category)}
+              className={`category-chip ${!currentCategory ? 'is-active' : ''}`}
+              onClick={() => handleCategoryChange('')}
             >
-              {category}
+              {t(language, 'browse.all')}
             </button>
-          ))}
+            {CATEGORIES.map((category) => (
+              <button
+                key={category}
+                type="button"
+                className={`category-chip ${currentCategory === category ? 'is-active' : ''}`}
+                onClick={() => handleCategoryChange(category)}
+              >
+                {category}
+              </button>
+            ))}
+            </div>
+          )}
         </div>
       </section>
 

--- a/Frontend/src/routes/Search.jsx
+++ b/Frontend/src/routes/Search.jsx
@@ -14,6 +14,7 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
   const [reloadToken, setReloadToken] = useState(0)
+  const [showCategories, setShowCategories] = useState(false)
 
   const currentPage = Math.max(1, parseInt(searchParams.get('page') || '1', 10))
   const currentCategory = searchParams.get('category') || ''
@@ -113,30 +114,43 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
           <span className="hero-search-tag">Live search</span>
         </div>
 
-        <div className="category-chip-row" aria-label="Quick categories">
+        <div className="category-options-wrap">
           <button
             type="button"
-            className={`category-chip ${!currentCategory ? 'is-active' : ''}`}
-            onClick={() => handleCategoryChange('')}
+            className="button button-secondary category-toggle"
+            aria-expanded={showCategories}
+            aria-controls="search-category-options"
+            onClick={() => setShowCategories((current) => !current)}
           >
-            All
+            Show options <span aria-hidden="true">{showCategories ? '→' : '●'}</span>
           </button>
-          {CATEGORIES.map((category) => (
+
+          {showCategories && (
+            <div id="search-category-options" className="category-chip-row" aria-label="Quick categories">
             <button
-              key={category}
               type="button"
-              className={`category-chip ${currentCategory === category ? 'is-active' : ''}`}
-              onClick={() => handleCategoryChange(category)}
+              className={`category-chip ${!currentCategory ? 'is-active' : ''}`}
+              onClick={() => handleCategoryChange('')}
             >
-              {category}
+              All
             </button>
-          ))}
+            {CATEGORIES.map((category) => (
+              <button
+                key={category}
+                type="button"
+                className={`category-chip ${currentCategory === category ? 'is-active' : ''}`}
+                onClick={() => handleCategoryChange(category)}
+              >
+                {category}
+              </button>
+            ))}
+            </div>
+          )}
         </div>
 
-        <div className="search-page-meta">
-          <span>{t(language, 'browse.browseListings')}</span>
-          <span>{normalizedQuery ? `Showing matches for "${effectiveMarketQuery}"` : 'Browse the newest campus listings.'}</span>
-        </div>
+        <p className="search-page-meta">
+          {t(language, 'browse.browseListings')}, {normalizedQuery ? `showing matches for "${effectiveMarketQuery}".` : 'Browse the newest campus listings.'}
+        </p>
       </section>
 
       <ItemGrid


### PR DESCRIPTION
## Summary
- Hid the Search and Browse category chips behind a compact `Show options` toggle.
- Added a cleaner inline reveal/collapse interaction to reduce visual clutter around the marketplace search area.
- Adjusted spacing and button sizing so the options row matches the existing category chip styling.

## Linked Issue
Closes #146

## Changes
- Added category toggle state to `Browse.jsx` and `Search.jsx`.
- Replaced always-visible category chip rows with a `Show options` button that reveals or hides the chips.
- Updated Search page meta copy to read cleanly: `Browse listings, Browse the newest campus listings.`
- Added shared CSS for the options wrapper, toggle sizing, and chip row alignment.

## How Tested (required)
- [x] Ran locally: `npm --prefix Frontend run build`
- [x] Tests: Vite production build passed successfully.
- [ ] CI checks: Pending after PR creation.

## Screenshots / Demo (if user-facing)
- Before: Category chips were always visible below the search/category area.
- After: Category chips are hidden behind `Show options`; clicking reveals them inline, clicking again hides them.
- Demo link (optional):

## Risk / Rollback
- Risk: Users need one extra click to access category filters from the hero area.
- Rollback plan: Revert commits on `hide-categories-toggle` or restore the previous always-visible `.category-chip-row` markup in `Browse.jsx` and `Search.jsx`.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant