### PR TITLE
Live search toggle

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -427,6 +427,8 @@ html.dark .feature-pill, html.dark .category-chip, html.dark .badge, html.dark .
 }
 .feature-pill, .category-chip, .item-category, .item-posted, .item-condition, .item-location, .trust-pill, .mini-location, .meta-pill, .hero-search-tag, .time-chip, .distance-chip { padding: 0.5rem 0.8rem; }
 .category-chip.is-active, .feature-pill.is-active, .badge-default, .status-badge.status-active, .item-condition.is-hot, .item-condition.is-popular { background: rgba(0, 87, 102, 0.12); color: var(--primary-strong); border-color: rgba(0, 87, 102, 0.18); }
+.live-search-toggle { cursor: pointer; font: inherit; }
+.live-search-toggle.is-active { background: rgba(0, 87, 102, 0.12); color: var(--primary-strong); border-color: rgba(0, 87, 102, 0.18); }
 
 .button, .hero-actions .button, .modal-actions .button, .browse-toolbar .button, .auth-form .button, .profile-card .button, .message-compose .button, .composer-submit {
   display: inline-flex; align-items: center; justify-content: center; min-height: 46px; padding: 0.85rem 1.15rem; border-radius: 999px; border: 1px solid transparent; transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, border-color 160ms ease, color 160ms ease;

--- a/Frontend/src/routes/Search.jsx
+++ b/Frontend/src/routes/Search.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import ItemGrid from '../components/ItemGrid'
 import { fetchItems } from '../services/api'
@@ -15,11 +15,18 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
   const [error, setError] = useState('')
   const [reloadToken, setReloadToken] = useState(0)
   const [showCategories, setShowCategories] = useState(false)
+  const [liveSearchEnabled, setLiveSearchEnabled] = useState(true)
+  const [searchDraft, setSearchDraft] = useState('')
+  const resultsRef = useRef(null)
 
   const currentPage = Math.max(1, parseInt(searchParams.get('page') || '1', 10))
   const currentCategory = searchParams.get('category') || ''
   const effectiveMarketQuery = typeof marketQuery === 'string' ? marketQuery : ''
   const setMarketQuery = typeof onMarketQueryChange === 'function' ? onMarketQueryChange : () => {}
+
+  useEffect(() => {
+    setSearchDraft(effectiveMarketQuery)
+  }, [effectiveMarketQuery])
 
   useEffect(() => {
     let isActive = true
@@ -83,6 +90,32 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
     })
   }
 
+  function handleSearchInputChange(event) {
+    const nextQuery = event.target.value
+    setSearchDraft(nextQuery)
+    if (liveSearchEnabled) {
+      setMarketQuery(nextQuery)
+    }
+  }
+
+  function handleSearchSubmit(event) {
+    event.preventDefault()
+    setMarketQuery(searchDraft)
+    window.requestAnimationFrame(() => {
+      resultsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }
+
+  function handleLiveSearchToggle() {
+    setLiveSearchEnabled((current) => {
+      const next = !current
+      if (next) {
+        setMarketQuery(searchDraft)
+      }
+      return next
+    })
+  }
+
   const normalizedQuery = effectiveMarketQuery.trim().toLowerCase()
   const visibleItems = normalizedQuery
     ? items.filter((item) => {
@@ -103,16 +136,23 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
           Search listings, narrow by category, and keep the marketplace focused on Ulsan College students.
         </p>
 
-        <div className="dashboard-search" role="search" aria-label="Marketplace search">
+        <form className="dashboard-search" role="search" aria-label="Marketplace search" onSubmit={handleSearchSubmit}>
           <input
-            value={effectiveMarketQuery}
-            onChange={(event) => setMarketQuery(event.target.value)}
+            value={searchDraft}
+            onChange={handleSearchInputChange}
             type="search"
             placeholder="Search textbooks, laptops, bikes..."
             aria-label="Search marketplace listings"
           />
-          <span className="hero-search-tag">Live search</span>
-        </div>
+          <button
+            type="button"
+            className={`hero-search-tag live-search-toggle ${liveSearchEnabled ? 'is-active' : ''}`}
+            aria-pressed={liveSearchEnabled}
+            onClick={handleLiveSearchToggle}
+          >
+            Live search: {liveSearchEnabled ? 'On' : 'Off'}
+          </button>
+        </form>
 
         <div className="category-options-wrap">
           <button
@@ -153,18 +193,20 @@ export default function Search({ currency, language = 'en', marketQuery, onMarke
         </p>
       </section>
 
-      <ItemGrid
-        items={visibleItems}
-        currency={currency}
-        isLoading={isLoading}
-        error={error}
-        pagination={pagination}
-        currentCategory={currentCategory}
-        onCategoryChange={handleCategoryChange}
-        onPageChange={handlePageChange}
-        onRetry={handleRetry}
-        language={language}
-      />
+      <div ref={resultsRef}>
+        <ItemGrid
+          items={visibleItems}
+          currency={currency}
+          isLoading={isLoading}
+          error={error}
+          pagination={pagination}
+          currentCategory={currentCategory}
+          onCategoryChange={handleCategoryChange}
+          onPageChange={handlePageChange}
+          onRetry={handleRetry}
+          language={language}
+        />
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Turned the Search page `Live search` pill into a real on/off toggle.
- Added manual search behavior when live search is off, so pressing Enter applies the query.
- Smoothly scrolls users to the results section after submitting a manual search.

## Linked Issue
Closes #148

## Changes
- Added `liveSearchEnabled` and `searchDraft` state to `Search.jsx`.
- Changed the search wrapper from a static div to a submit-enabled search form.
- Updated the `Live search` pill into a clickable toggle showing `Live search: On` or `Live search: Off`.
- Added smooth scrolling to the results section after pressing Enter.
- Added styling for the live search toggle active/clickable state.

## How Tested (required)
- [x] Ran locally: `npm --prefix Frontend run build`
- [x] Tests: Vite production build passed successfully.
- [ ] CI checks: Pending after PR creation.

## Screenshots / Demo (if user-facing)
- Before: `Live search` appeared as a static pill and did not respond to clicks.
- After: `Live search` toggles between On/Off; when Off, pressing Enter applies the search and scrolls to results.
- Demo link (optional):

## Risk / Rollback
- Risk: Users may need to understand the difference between live filtering and manual Enter-to-search behavior.
- Rollback plan: Revert the two commits on `live-search-toggle` to restore the previous static `Live search` pill.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant