### PR TITLE
Fix dark mode readability

### DIFF
--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -1248,6 +1248,46 @@ html.dark .message-compose { background: rgba(18,27,30,0.95); }
 .detail-actions { display: flex; gap: 0.6rem; margin-top: 0.6rem; flex-wrap: wrap; }
 .detail-actions .button { min-width: 0; flex: 1 1 auto; }
 
+html.dark .detail-sidebar {
+  background: linear-gradient(180deg, rgba(22, 37, 41, 0.98), rgba(10, 22, 26, 0.98));
+  border-color: rgba(129, 234, 255, 0.18);
+  color: #fbfffd;
+}
+html.dark .detail-title,
+html.dark .detail-seller-name-row strong,
+html.dark .detail-contact-card strong {
+  color: #ffffff;
+}
+html.dark .detail-price { color: #b9f5ff; }
+html.dark .detail-chip {
+  background: rgba(8, 18, 21, 0.82);
+  border-color: rgba(226, 246, 243, 0.16);
+  color: #f3fffc;
+}
+html.dark .detail-description {
+  color: #e9f6f4;
+  background: rgba(8, 18, 21, 0.44);
+  border: 1px solid rgba(226, 246, 243, 0.12);
+  border-radius: 16px;
+  padding: 0.85rem;
+}
+html.dark .detail-seller-card,
+html.dark .detail-contact-card {
+  background: linear-gradient(180deg, rgba(27, 44, 48, 0.96), rgba(13, 27, 31, 0.96));
+  border-color: rgba(129, 234, 255, 0.18);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.34);
+}
+html.dark .detail-seller-label,
+html.dark .detail-seller-note {
+  color: #cfe2df;
+}
+html.dark .detail-contact-list { color: #f3fffc; }
+html.dark .detail-verified-badge {
+  background: linear-gradient(135deg, rgba(129, 234, 255, 0.16), rgba(240, 204, 117, 0.14));
+  color: #ffffff;
+  border: 1px solid rgba(129, 234, 255, 0.2);
+}
+
 /* Lightbox polish */
 .detail-lightbox { position: fixed; inset: 0; z-index: 120; display: grid; place-items: center; background: rgba(6,24,19,0.6); }
 .detail-lightbox-panel { position: relative; max-width: min(92vw, 1100px); width: 100%; padding: 1rem; display: grid; place-items: center; }

--- a/Frontend/src/assets/styles/global.css
+++ b/Frontend/src/assets/styles/global.css
@@ -289,6 +289,24 @@ html.dark .nav-links a.is-active, html.dark .nav-pill.is-active {
 }
 .currency-menu-item:hover, .currency-menu-item[aria-pressed='true'] { background: linear-gradient(135deg, rgba(0, 87, 102, 0.1), rgba(23, 137, 79, 0.08)); color: #06424d; }
 
+html.dark .currency-hamburger-wrapper {
+  border-color: rgba(226, 246, 243, 0.18);
+  background: linear-gradient(180deg, rgba(28, 45, 49, 0.96), rgba(13, 26, 30, 0.98));
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.36), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+html.dark .language-indicator { color: #f3fffc; }
+html.dark .currency-menu, html.dark .search-menu {
+  background: linear-gradient(180deg, rgba(26, 43, 47, 0.99), rgba(9, 21, 25, 0.99));
+  border-color: rgba(129, 234, 255, 0.22);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.62);
+}
+html.dark .menu-section-title { color: #b9d9d5; }
+html.dark .currency-menu-item { color: #f6fffd; }
+html.dark .currency-menu-item:hover, html.dark .currency-menu-item[aria-pressed='true'] {
+  background: linear-gradient(135deg, rgba(129, 234, 255, 0.16), rgba(240, 204, 117, 0.1));
+  color: #ffffff;
+}
+
 @media (max-width: 1100px) {
   .nav-links {
     flex-wrap: nowrap;


### PR DESCRIPTION
## Summary
- Improved dark-mode readability for the language selector and dropdown menu.
- Improved dark-mode contrast on listing detail cards, chips, seller info, and contact sections.
- Kept the existing layout and interactions unchanged while making text easier to read.

## Linked Issue
Closes #150

## Changes
- Added dark-mode styling for the language selector wrapper, current language label, dropdown menu, section title, and language options.
- Added dark-mode styling for listing detail sidebar surfaces, title, price, chips, description box, seller card, contact card, and verified badge.
- Preserved the existing component structure and only adjusted targeted CSS contrast rules.

## How Tested (required)
- [x] Ran locally: `npm --prefix Frontend run build`
- [x] Tests: Vite production build passed successfully.
- [ ] CI checks: Pending after PR creation.

## Screenshots / Demo (if user-facing)
- Before: Dark mode made the language selector/dropdown and listing detail text hard to read against light or low-contrast surfaces.
- After: Dark mode uses stronger surfaces and clearer text colors for the affected areas.
- Demo link (optional):

## Risk / Rollback
- Risk: Dark-mode color changes may need small visual tuning after review on different screens.
- Rollback plan: Revert commits `650e293` and `7c950c7` on `fix-dark-mode-readability`.

## Checklist
- [x] I linked an Issue
- [x] I used a branch (not direct to `main`)
- [x] I wrote clear commit messages
- [ ] I updated docs if needed (`/docs`)
- [ ] I added/updated tests if relevant