### PR TITLE
Fix sell-page owner actions for own listings

### DIFF
--- a/Frontend/src/components/ItemCard.jsx
+++ b/Frontend/src/components/ItemCard.jsx
@@ -108,18 +108,10 @@ export default function ItemCard({ item, currency, language = 'en' }) {
   const isSeller = Boolean(currentUserId && sellerId && String(currentUserId) === String(sellerId))
   const initialListingStatus = String(item?.status || 'active').toLowerCase()
   const [listingStatus, setListingStatus] = useState(initialListingStatus)
-  const sellerLabelMap = {
-    active: 'On sale by',
-    reserved: 'Reserved by',
-    sold: 'Sold by',
-    removed: 'On sale by',
-    draft: 'On sale by',
-  }
-  const sellerLabel = sellerLabelMap[listingStatus] || 'On sale by'
   const statusOptions = [
     { value: 'active', label: 'On sale' },
     { value: 'reserved', label: 'Reserved' },
-    { value: 'sold', label: 'Sold' },
+    { value: 'sold', label: 'Sold out' },
   ]
   const initialLoveCount = Number.isFinite(Number(item?.favoritesCount)) ? Math.max(0, Number(item.favoritesCount)) : 0
   const [isLoved, setIsLoved] = useState(Boolean(item?.isLoved || item?.isFavorited || item?.isLiked || item?.liked))
@@ -262,18 +254,53 @@ export default function ItemCard({ item, currency, language = 'en' }) {
         <div className="item-compact-meta">
           {/* keep meta area for price/other small bits; status moved to header right */}
         </div>
-        <div className="item-actions-row compact-actions" aria-label="Buyer actions">
-          <button
-            type="button"
-            className="item-action-button item-action-message button button-primary"
-            onClick={(event) => {
-              event.stopPropagation()
-              handleMessageSeller()
-            }}
-          >
-            <span>{t(language, 'dashboard.messageSeller')}</span>
-          </button>
+        <div className="item-actions-row compact-actions" aria-label={isSeller ? 'Seller actions' : 'Buyer actions'}>
+          {isSeller ? (
+            <button
+              type="button"
+              className="item-action-button item-action-edit button button-primary"
+              onClick={(event) => {
+                event.stopPropagation()
+                openStatusEditor()
+              }}
+            >
+              <span>Edit listing</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="item-action-button item-action-message button button-primary"
+              onClick={(event) => {
+                event.stopPropagation()
+                handleMessageSeller()
+              }}
+            >
+              <span>{t(language, 'dashboard.messageSeller')}</span>
+            </button>
+          )}
         </div>
+        {isSeller && isEditingStatus ? (
+          <div className="item-status-editor" onClick={(event) => event.stopPropagation()}>
+            <label className="item-status-editor-label">
+              Listing status
+              <select value={statusDraft} onChange={(event) => setStatusDraft(event.target.value)}>
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <div className="item-status-editor-actions">
+              <button type="button" className="button button-primary" onClick={handleSaveStatus} disabled={isSavingStatus}>
+                {isSavingStatus ? 'Saving…' : 'Save status'}
+              </button>
+              <button type="button" className="button button-secondary" onClick={openStatusEditor} disabled={isSavingStatus}>
+                Cancel
+              </button>
+            </div>
+            {statusMessage ? <p className="message-status is-success">{statusMessage}</p> : null}
+            {statusError ? <p className="message-status is-error">{statusError}</p> : null}
+          </div>
+        ) : null}
       </div>
     </article>
   )

--- a/Frontend/src/routes/ItemDetail.jsx
+++ b/Frontend/src/routes/ItemDetail.jsx
@@ -117,6 +117,15 @@ export default function ItemDetail({ currency, language = 'en' }) {
   const sellerAvatar = effectiveItem?.sellerAvatarUrl || effectiveItem?.sellerAvatar || effectiveItem?.seller_avatar || effectiveItem?.seller_avatar_url || ''
   const detailRows = useMemo(() => buildDetailRows(effectiveItem), [effectiveItem])
   const sellerLocation = sellerProfile?.location || effectiveItem?.location || 'Campus'
+  const sellerId = sellerProfile?.id || sellerProfile?._id || effectiveItem?.seller_id || effectiveItem?.sellerId || effectiveItem?.seller?.id || effectiveItem?.seller?._id || ''
+  const sellerProfileState = {
+    seller: {
+      id: sellerId,
+      firstName: sellerName,
+      avatarUrl: sellerProfile?.avatarUrl || sellerAvatar,
+      location: sellerLocation,
+    },
+  }
   const sellerEmail = sellerProfile?.email || effectiveItem?.sellerEmail || ''
   const sellerPhone = sellerProfile?.phone || effectiveItem?.sellerPhone || ''
   const conditionLabel = getConditionLabel(effectiveItem)
@@ -183,7 +192,7 @@ export default function ItemDetail({ currency, language = 'en' }) {
 
   useEffect(() => {
     let isActive = true
-    const sellerId = item?.seller_id || item?.sellerId || ''
+    const sellerId = item?.seller_id || item?.sellerId || item?.seller?.id || item?.seller?._id || ''
 
     async function loadSellerProfile() {
       if (!sellerId) {
@@ -209,7 +218,7 @@ export default function ItemDetail({ currency, language = 'en' }) {
     return () => {
       isActive = false
     }
-  }, [item?.sellerId, item?.seller_id])
+  }, [item?.sellerId, item?.seller_id, item?.seller?.id, item?.seller?._id])
 
   async function handleMessageSeller() {
     if (!item?._id) return
@@ -368,9 +377,13 @@ export default function ItemDetail({ currency, language = 'en' }) {
             <p className="detail-description">{effectiveItem?.description}</p>
 
             <div className="detail-seller-card">
-              <Link to={`/profile/${effectiveItem?.seller_id || effectiveItem?.sellerId || ''}`} onClick={(e) => e.stopPropagation()}>
+              {sellerId ? (
+                <Link to={`/profile/${sellerId}`} state={sellerProfileState} onClick={(e) => e.stopPropagation()}>
+                  <Avatar src={sellerProfile?.avatarUrl || sellerAvatar} alt={sellerName} size={56} />
+                </Link>
+              ) : (
                 <Avatar src={sellerProfile?.avatarUrl || sellerAvatar} alt={sellerName} size={56} />
-              </Link>
+              )}
               <div className="detail-seller-copy">
                 <p className="detail-seller-label">Seller</p>
                 <div className="detail-seller-name-row">
@@ -398,9 +411,15 @@ export default function ItemDetail({ currency, language = 'en' }) {
               <button className="button button-primary" type="button" onClick={handleMessageSeller}>
                 Message seller
               </button>
-              <Link className="button button-secondary" to={`/profile/${effectiveItem?.seller_id || effectiveItem?.sellerId || ''}`}>
-                View profile
-              </Link>
+              {sellerId ? (
+                <Link className="button button-secondary" to={`/profile/${sellerId}`} state={sellerProfileState}>
+                  View profile
+                </Link>
+              ) : (
+                <span className="button button-secondary" aria-disabled="true">
+                  View profile
+                </span>
+              )}
               <button className="button button-secondary" type="button" onClick={() => navigate(-1)}>
                 Back
               </button>


### PR DESCRIPTION
Closes #153.\n\nThis updates the sell-page item cards so owners see edit/status controls instead of a buyer-only Message seller button. It also keeps the status options aligned with the backend-supported states while showing Sold out in the UI.