### PR TITLE
docs: add final portfolio

### DIFF
--- a/portfolio/01-project-overview/FINAL_MVP_SCOPE.md
+++ b/portfolio/01-project-overview/FINAL_MVP_SCOPE.md
@@ -1,0 +1,61 @@
+# Final MVP Scope
+
+## Final Core User Flow
+
+1. A student opens the CampusMarketplace frontend.
+2. The student signs up with a valid `@office.uc.ac.kr` email.
+3. The student verifies the OTP flow when email delivery is configured.
+4. The student logs in and receives a JWT.
+5. The student browses active listings.
+6. The student creates a listing with title, description, price, category, status, and image data.
+7. Another student searches or browses listings, opens an item detail page, views seller information, and can use messaging/profile/review features where available.
+8. The seller manages listing status from the dashboard or API.
+
+## Features Included in Final MVP
+
+- React + Vite frontend routing and shared layout
+- Signup/login with campus email validation
+- OTP verification endpoints and email delivery support
+- JWT-authenticated protected flows
+- Marketplace item list, item detail, create item, update item status
+- MongoDB-backed user and item storage
+- Image upload support with Cloudinary configuration and local fallback
+- User profile, edit profile, password update, avatar upload/delete
+- Public seller profiles and seller reviews
+- Favorites/loved items
+- Messaging thread and message API endpoints
+- Search and category browsing routes
+- Dark mode and UI polish
+- Language and currency preference support
+- GitHub Pages frontend deployment configuration
+- Render-oriented backend configuration notes
+
+## Features That Work Reliably
+
+- Frontend build with Vite
+- Backend Flask app startup with required environment variables
+- API route definitions for auth, profile, items, messages, users, reviews, favorites, uploads, and health checks
+- Campus email/password validation logic
+- Listing CRUD basics through backend endpoints
+- Profile/avatar endpoint logic
+- GitHub Pages frontend build workflow
+
+## Features That Work With Limitations
+
+- Email OTP requires SendGrid or SMTP environment configuration.
+- Cloudinary image storage requires Cloudinary environment variables; otherwise local storage is used in development and production-like environments may reject uploads.
+- Integration tests in `tests/test_profile_endpoints.py` require `TEST_MONGODB_URI` and a Flask test client fixture that is not currently included.
+- Frontend test script is a placeholder that exits successfully with "No frontend tests."
+- Live frontend and backend deployment reliability depends on external GitHub Pages and Render configuration.
+- Some early docs mention planned features or older stacks that changed during the semester.
+
+## Features Excluded From Final MVP
+
+- Payment processing
+- Shipping or delivery workflow
+- Native mobile app
+- Admin moderation dashboard
+- Recommendation engine
+- Full real-time chat infrastructure beyond current message endpoints
+- Cross-campus expansion
+- Production-grade automated regression suite

--- a/portfolio/01-project-overview/PROJECT_SUMMARY.md
+++ b/portfolio/01-project-overview/PROJECT_SUMMARY.md
@@ -1,0 +1,48 @@
+# Project Summary
+
+## Team
+
+- Team name: CampusMarketplace / Campus Marketplace
+- Project name: CampusMarketplace
+- Team members: Gayatri K. Bhandari, Aayuska Rai, Sudarshan Rai, Sagar Sob, Ananda Tamang
+- Repository: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace
+- Frontend demo: https://capstonedesign-spring2026-ulsancollege.github.io/campusMarketPlace/
+
+## Target User
+
+University students at Ulsan College who want to buy, sell, request, or discover affordable items and services inside a trusted campus community.
+
+## Problem
+
+Students often need textbooks, electronics, dorm supplies, and other second-hand goods, but general marketplaces are open to the public and can be less safe or less relevant for campus trading.
+
+## Value Statement
+
+CampusMarketplace helps verified students trade items with other students in a focused, campus-only marketplace.
+
+## Final MVP Summary
+
+The final app combines a React + Vite frontend with a Flask + MongoDB backend. It supports campus-email signup with OTP verification, login, marketplace browsing, item creation and management, image upload support, profiles, favorites, public seller profiles, seller reviews, messaging endpoints, search/category browsing, dark mode, currency/language preferences, and deployment-oriented configuration.
+
+## Important Evidence
+
+- Original project pitch: [docs/PROJECTPITCH.md](../../docs/PROJECTPITCH.md)
+- Project overview: [docs/PROJECT_1.md](../../docs/PROJECT_1.md)
+- Design document: [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md)
+- User stories: [docs/USERSTORIES.md](../../docs/USERSTORIES.md)
+- Wireframes: [docs/WIREFRAME.md](../../docs/WIREFRAME.md)
+- Architecture sketch: [docs/Architecture_sketch.md](../../docs/Architecture_sketch.md)
+- Midterm submission: [docs/Midterm/MIDTERM_SUBMISSION.md](../../docs/Midterm/MIDTERM_SUBMISSION.md)
+- Backend implementation: [app.py](../../app.py)
+- Frontend app: [Frontend/src/App.jsx](../../Frontend/src/App.jsx)
+- README setup notes: [README.md](../../README.md)
+
+## Portfolio Sections
+
+- [Final MVP Scope](FINAL_MVP_SCOPE.md)
+- [Scope Decisions](SCOPE_DECISIONS.md)
+- [Semester Journey](../02-semester-journey/SEMESTER_JOURNEY.md)
+- [Final Product Docs](../04-final-product/FINAL_MVP_DEMO.md)
+- [QA and Stabilization](../05-qa-and-stabilization/QA_REPORT.md)
+- [AI and Code Ownership](../06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md)
+- [Final Presentation](../07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)

--- a/portfolio/01-project-overview/SCOPE_DECISIONS.md
+++ b/portfolio/01-project-overview/SCOPE_DECISIONS.md
@@ -1,0 +1,25 @@
+# Scope Decisions
+
+| Feature or idea | Final status | Why | Evidence |
+|---|---|---|---|
+| Campus-only marketplace | Included | Core project purpose from the first pitch | [PROJECTPITCH.md](../../docs/PROJECTPITCH.md) |
+| React + Vite frontend | Included | Became the final frontend stack and is used by `Frontend/` | [Frontend/package.json](../../Frontend/package.json) |
+| Flask backend | Included | Main API implementation is in Flask | [app.py](../../app.py) |
+| MongoDB | Included | Final backend stores users/items/messages/reviews in MongoDB collections | [app.py](../../app.py) |
+| Campus email signup | Included | Required trust gate for Ulsan College students | [README.md](../../README.md) |
+| OTP email verification | Working with limitations | Endpoints and email sender exist, but real delivery needs SendGrid/SMTP env vars | [app.py](../../app.py), [README.md](../../README.md) |
+| Login and JWT auth | Included | Required for dashboard/profile/listing ownership | [app.py](../../app.py) |
+| Browse active listings | Included | Main buyer flow | [Frontend/src/routes/Browse.jsx](../../Frontend/src/routes/Browse.jsx), [app.py](../../app.py) |
+| Create item listing | Included | Main seller flow | [Frontend/src/routes/Dashboard.jsx](../../Frontend/src/routes/Dashboard.jsx), [app.py](../../app.py) |
+| Search and category filtering | Included | Needed to find listings | [Frontend/src/routes/Search.jsx](../../Frontend/src/routes/Search.jsx), [Frontend/src/constants/categories.js](../../Frontend/src/constants/categories.js) |
+| Image upload | Working with limitations | Supports Cloudinary or local storage, requires env configuration | [README.md](../../README.md), [app.py](../../app.py) |
+| User dashboard | Included | Lets signed-in users manage their experience | [Frontend/src/routes/Dashboard.jsx](../../Frontend/src/routes/Dashboard.jsx) |
+| Profile editing and avatars | Included | Final polish and user identity feature | [Frontend/src/routes/Profile.jsx](../../Frontend/src/routes/Profile.jsx), [Frontend/src/routes/EditProfile.jsx](../../Frontend/src/routes/EditProfile.jsx), [docs/ProfileTesting.md](../../docs/ProfileTesting.md) |
+| Favorites/loved items | Included | Implemented in backend/profile evidence | [tests/test_profile_endpoints.py](../../tests/test_profile_endpoints.py) |
+| Seller reviews | Included | Implemented in backend and integration test draft | [tests/test_profile_endpoints.py](../../tests/test_profile_endpoints.py) |
+| Messaging | Working with limitations | Backend routes and frontend page exist, but final demo should have a backup plan | [Frontend/src/routes/Messages.jsx](../../Frontend/src/routes/Messages.jsx), [app.py](../../app.py) |
+| Payments | Cut | Out of scope and not needed for campus in-person exchange | [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md) |
+| Shipping/delivery | Cut | Marketplace is campus/local exchange | [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md) |
+| Admin dashboard | Nice Later | Mentioned as optional in early scope, not required for final MVP | [docs/PROJECT_1.md](../../docs/PROJECT_1.md) |
+| Recommendation engine | Nice Later | Advanced feature held after MVP | [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md) |
+| Native mobile app | Cut | Responsive web app is enough for capstone MVP | [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md) |

--- a/portfolio/02-semester-journey/SEMESTER_JOURNEY.md
+++ b/portfolio/02-semester-journey/SEMESTER_JOURNEY.md
@@ -1,0 +1,51 @@
+# Semester Journey
+
+CampusMarketplace moved from a planning-heavy campus marketplace concept into a React + Vite frontend with a Flask + MongoDB API. The semester evidence is uneven but useful: early weeks document project setup and scope, midterm materials show a deployed frontend and signup story, Sprint 3 documents MVP verification, and later commits show final product polish, messaging, item detail, profiles, dark mode, and search/category behavior.
+
+## Weekly Files
+
+- [Week 01](weekly-sprints/WEEK_01.md)
+- [Week 02](weekly-sprints/WEEK_02.md)
+- [Week 03](weekly-sprints/WEEK_03.md)
+- [Week 04](weekly-sprints/WEEK_04.md)
+- [Week 05](weekly-sprints/WEEK_05.md)
+- [Week 06](weekly-sprints/WEEK_06.md)
+- [Week 07](weekly-sprints/WEEK_07.md)
+- [Week 08](weekly-sprints/WEEK_08.md)
+- [Week 09](weekly-sprints/WEEK_09.md)
+- [Week 10](weekly-sprints/WEEK_10.md)
+- [Week 11](weekly-sprints/WEEK_11.md)
+- [Week 12](weekly-sprints/WEEK_12.md)
+- [Week 13](weekly-sprints/WEEK_13.md)
+- [Week 14](weekly-sprints/WEEK_14.md)
+- [Week 15](weekly-sprints/WEEK_15.md)
+- [Week 16](weekly-sprints/WEEK_16.md)
+
+## Sprint Summaries
+
+- [Sprint 01](sprint-summaries/SPRINT_01.md)
+- [Sprint 02](sprint-summaries/SPRINT_02.md)
+- [Sprint 03](sprint-summaries/SPRINT_03.md)
+- [Sprint 04](sprint-summaries/SPRINT_04.md)
+- [Final Sprint](sprint-summaries/FINAL_SPRINT.md)
+
+## Major Evidence
+
+- Project pitch: [docs/PROJECTPITCH.md](../../docs/PROJECTPITCH.md)
+- Team agreement: [docs/TEAMAGREEMENT.md](../../docs/TEAMAGREEMENT.md)
+- Project overview: [docs/PROJECT_1.md](../../docs/PROJECT_1.md)
+- Design document: [docs/Design Doc v1.md](../../docs/Design%20Doc%20v1.md)
+- User stories: [docs/USERSTORIES.md](../../docs/USERSTORIES.md)
+- Wireframes: [docs/WIREFRAME.md](../../docs/WIREFRAME.md)
+- Architecture sketch: [docs/Architecture_sketch.md](../../docs/Architecture_sketch.md)
+- Midterm submission: [docs/Midterm/MIDTERM_SUBMISSION.md](../../docs/Midterm/MIDTERM_SUBMISSION.md)
+- Midterm deck: [docs/Midterm/Ulsan_College_Marketplace.pptx](../../docs/Midterm/Ulsan_College_Marketplace.pptx)
+- Profile testing notes: [docs/ProfileTesting.md](../../docs/ProfileTesting.md)
+- AI ownership audit: [docs/Sprint_Packet/Week_9/AI Code Ownership Audit.md](../../docs/Sprint_Packet/Week_9/AI%20Code%20Ownership%20Audit.md)
+
+## Major PR and Commit Evidence
+
+- Vite setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/26
+- Backend setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/29
+- Week 11 MVP verification PR set: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pulls?q=55+56+57+58+59+60+61+62
+- Late final polish commits include item detail, profile, messages, dark mode, search/category toggles, and readability fixes in the June 2026 git history.

--- a/portfolio/02-semester-journey/sprint-summaries/FINAL_SPRINT.md
+++ b/portfolio/02-semester-journey/sprint-summaries/FINAL_SPRINT.md
@@ -1,0 +1,37 @@
+# Final Sprint Summary
+
+## Goal
+
+Package the real semester work into a final portfolio and prepare the final presentation/demo.
+
+## Planned Work
+
+- Create `portfolio/README.md`
+- Create required final portfolio folders and files
+- Link all existing planning, sprint, QA, AI, and product evidence
+- Document known gaps honestly
+- Prepare script, defense prep, and backup demo plan
+
+## Completed Work
+
+- Portfolio structure created under `portfolio/`.
+- Required overview, journey, final product, QA, AI, presentation, and individual portfolio files created.
+- Existing docs and code evidence linked instead of copied or rewritten.
+
+## Incomplete Work
+
+- Other individual portfolio pages still need to be created by their owners.
+- Screenshots and final slide exports should be added if the team uses slides.
+- Broken-link and demo rehearsal checks should be repeated before submission.
+
+## Strongest Evidence
+
+- [Portfolio README](../../README.md)
+- [Final MVP Demo](../../04-final-product/FINAL_MVP_DEMO.md)
+- [QA Report](../../05-qa-and-stabilization/QA_REPORT.md)
+- [Final Presentation Script](../../07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)
+
+## Bugs or Risks
+
+- External services may fail during demo if environment variables or accounts are missing.
+- Some historical weeks do not have full sprint packet evidence.

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_01.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_01.md
@@ -1,0 +1,44 @@
+# Sprint 01 Summary
+
+## Goal
+
+Finalize the project idea, team agreement, repository setup, user stories, initial architecture, and early frontend direction.
+
+## Planned Work
+
+- Create repository and project documentation
+- Define roles and GitHub workflow
+- Draft project pitch and team agreement
+- Start frontend setup and signup UI
+
+## Completed Work
+
+- Project pitch, team agreement, and project overview were created.
+- Early homepage and signup UI work appears in git history.
+- User stories, wireframes, design doc, and architecture sketch were added.
+
+## Incomplete Work
+
+- Frontend/backend integration was not complete.
+- No stable product demo existed yet.
+
+## Major Scope Changes
+
+- Database direction changed toward MongoDB.
+- Project moved toward a React/Vite frontend later in Sprint 2.
+
+## Strongest Evidence
+
+- [Week 01](../weekly-sprints/WEEK_01.md)
+- [Week 02](../weekly-sprints/WEEK_02.md)
+- [Week 03](../weekly-sprints/WEEK_03.md)
+- [docs/PROJECT_1.md](../../../docs/PROJECT_1.md)
+
+## Bugs or Risks
+
+- Development environments were not fully configured.
+- Technology stack and backend integration were still uncertain.
+
+## Moved Into Next Sprint
+
+- Vite setup, backend setup, deployment, and midterm demo preparation.

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_02.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_02.md
@@ -1,0 +1,46 @@
+# Sprint 02 Summary
+
+## Goal
+
+Prepare a believable midterm demo and stabilize the foundation with Vite, backend setup, deployment, and signup/login direction.
+
+## Planned Work
+
+- Vite frontend environment
+- Backend setup
+- GitHub Pages deployment
+- Midterm deck and demo story
+- Login/signup flow proof
+
+## Completed Work
+
+- Vite frontend setup was merged.
+- Backend setup was merged.
+- GitHub Pages deployment was documented and repaired.
+- Midterm submission and deck were prepared.
+
+## Incomplete Work
+
+- Full frontend/backend integration remained unstable.
+- Item listing workflow was still planned.
+
+## Major Scope Changes
+
+- The team focused the midterm demo on a smaller auth/signup story rather than a full marketplace loop.
+
+## Strongest Evidence
+
+- [SPRINT_2.md](../../../docs/Sprint_Packet/SPRINT_2.md)
+- [Week 06](../weekly-sprints/WEEK_06.md)
+- [Week 07](../weekly-sprints/WEEK_07.md)
+- [Week 08](../weekly-sprints/WEEK_08.md)
+- [Midterm submission](../../../docs/Midterm/MIDTERM_SUBMISSION.md)
+
+## Bugs or Risks
+
+- GitHub Pages deployment originally failed under the default Jekyll workflow.
+- Integration remained a blocker before the final MVP flow.
+
+## Moved Into Next Sprint
+
+- MVP verification, auth hardening, item API work, and code ownership documentation.

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_03.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_03.md
@@ -1,0 +1,49 @@
+# Sprint 03 Summary
+
+## Goal
+
+Stabilize and verify the MVP end-to-end flow with engineering ownership evidence.
+
+## Planned Work
+
+- Signup/login reliability
+- Verification gate behavior
+- Item posting and browsing backend readiness
+- Frontend-backend integration
+- Bug tracking and ownership
+
+## Completed Work
+
+- Email verification gate merged.
+- Item schema validation and MongoDB indexes merged.
+- Item listing and item detail endpoints merged.
+- Post item composer form connected.
+- Mock data replaced with real API calls.
+- JWT and signup lifecycle bugs were fixed.
+
+## Incomplete Work
+
+- Email delivery still needed provider integration.
+- Automated tests were not yet enforced by CI.
+- Some frontend browse/listing paths still needed completion.
+
+## Major Scope Changes
+
+- Search/filter, chat, payment, and ratings were marked as nice-later or post-core until the MVP flow stabilized.
+
+## Strongest Evidence
+
+- [SPRINT_3.md](../../../docs/Sprint_Packet/SPRINT_3.md)
+- [Week 09](../weekly-sprints/WEEK_09.md)
+- [Week 10](../weekly-sprints/WEEK_10.md)
+- [Week 11](../weekly-sprints/WEEK_11.md)
+- PR #55 through PR #62 listed in the Week 11 packet.
+
+## Bugs or Risks
+
+- Verification email sending pipeline incomplete.
+- Manual testing was stronger than automated coverage.
+
+## Moved Into Next Sprint
+
+- Listings UI, email delivery, pytest smoke tests, Cloudinary upload, dashboard, and search/category filtering.

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_04.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_04.md
@@ -1,0 +1,46 @@
+# Sprint 04 Summary
+
+## Goal
+
+Complete the marketplace loop and prepare for final submission with listings UI, OTP email, tests, search, dashboard, images, and final documentation.
+
+## Planned Work
+
+- Browse UI connected to real backend data
+- OTP email sending with SendGrid/SMTP
+- Pytest smoke tests
+- Cloudinary image upload
+- Search and category filtering
+- Dashboard item management
+- Final UI polish and deployment verification
+
+## Completed Work
+
+- Final code contains item CRUD, search/browse routes, dashboard, profile/avatar support, favorites, seller reviews, messaging endpoints, image upload support, dark mode, language/currency support, and deployment configuration notes.
+- Week 13 packet records many final feature completions.
+
+## Incomplete Work
+
+- Formal sprint packet evidence is incomplete for Weeks 14-16.
+- Tests need additional setup before they are executable in CI.
+- OTP and Cloudinary require external environment configuration.
+
+## Major Scope Changes
+
+- Payment, recommendation engine, native mobile app, and cross-campus expansion remained out of scope.
+
+## Strongest Evidence
+
+- [SPRINT_4.md](../../../docs/Sprint_Packet/SPRINT_4.md)
+- [Week 12](../weekly-sprints/WEEK_12.md)
+- [Week 13](../weekly-sprints/WEEK_13.md)
+- [app.py](../../../app.py)
+- [Frontend/src](../../../Frontend/src)
+
+## Bugs or Risks
+
+- Email provider, Cloudinary, MongoDB, and Render/GitHub Pages deployment rely on environment variables and external services.
+
+## Moved Into Final Sprint
+
+- Final docs, QA summary, backup demo plan, technical defense prep, and link cleanup.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_01.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_01.md
@@ -1,0 +1,20 @@
+# Week 01
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week1.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week1.md)
+- Project pitch: [docs/PROJECTPITCH.md](../../../docs/PROJECTPITCH.md)
+- Team agreement: [docs/TEAMAGREEMENT.md](../../../docs/TEAMAGREEMENT.md)
+- Early project overview: [docs/PROJECT_1.md](../../../docs/PROJECT_1.md)
+
+## Summary
+
+The team finalized the CampusMarketplace idea, created the repository, started documentation, defined collaboration expectations, and planned the project architecture.
+
+## Evidence Notes
+
+Git history from March 11-13, 2026 shows the first project pitch, team member updates, backend tool choice, team agreement, docs organization, GitHub templates, and the first weekly packet.
+
+## Gap
+
+The week did not yet have a working product demo. The sprint packet documents planning and repository setup.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_02.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_02.md
@@ -1,0 +1,18 @@
+# Week 02
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week2.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week2.md)
+- User stories: [docs/USERSTORIES.md](../../../docs/USERSTORIES.md)
+
+## Summary
+
+Week 02 focused on frontend/backend initialization, role assignment, project board setup, and initial UI/API direction.
+
+## Evidence Notes
+
+Git history around March 17-20, 2026 shows homepage improvements, footer/logo effects, signup boilerplate, email validation, password rules, confirm password, and README updates.
+
+## Gap
+
+The packet marks the demo link as TBD and says frontend/backend were not fully connected yet.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_03.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_03.md
@@ -1,0 +1,16 @@
+# Week 03
+
+## Materials We Have
+
+- Design document: [docs/Design Doc v1.md](../../../docs/Design%20Doc%20v1.md)
+- Wireframes: [docs/WIREFRAME.md](../../../docs/WIREFRAME.md)
+- Architecture sketch: [docs/Architecture_sketch.md](../../../docs/Architecture_sketch.md)
+- Commit history from March 25, 2026
+
+## Summary
+
+No formal Week 03 packet was found in the repo. Available evidence shows project planning expanded with wireframes, a design document, architecture sketch, MongoDB technology decision, and sprint documentation cleanup.
+
+## Note
+
+We do not have a formal weekly sprint packet for this week, so this page links the planning artifacts that exist.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_04.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_04.md
@@ -1,0 +1,18 @@
+# Week 04
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week4.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week4.md)
+
+## Summary
+
+Week 04 planned the registration, login, logout, MongoDB, Flask setup, and Bootstrap/Jinja-based UI path. The packet also documents the shift toward issue-driven Git workflow.
+
+## Strongest Evidence
+
+- The packet names tasks for Flask app setup, MongoDB Atlas, registration/login routes, forms, and QA.
+- It also records planned risks around Flask/MongoDB experience and `.env` secrets.
+
+## Gap
+
+The file still contains several placeholders and is more planning-focused than final evidence.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_05.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_05.md
@@ -1,0 +1,18 @@
+# Week 05
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week5.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week5.md)
+
+## Summary
+
+Week 05 focused on building signup end-to-end: signup UI, campus email validation, MongoDB connection, backend signup logic, and integration testing.
+
+## Shipped Evidence
+
+- The packet marks signup page UI, MongoDB connection, and successful registration as shipped.
+- It documents MongoDB authentication/configuration issues and email validation bugs.
+
+## Gap
+
+The packet does not include all PR links directly, so the portfolio uses it as process evidence rather than full proof of every task.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_06.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_06.md
@@ -1,0 +1,21 @@
+# Week 06
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week6.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week6.md)
+- Sprint 2 summary: [docs/Sprint_Packet/SPRINT_2.md](../../../docs/Sprint_Packet/SPRINT_2.md)
+- Midterm submission: [docs/Midterm/MIDTERM_SUBMISSION.md](../../../docs/Midterm/MIDTERM_SUBMISSION.md)
+
+## Summary
+
+Week 06 hardened the project for the midterm direction. The team set up Vite, backend dependencies, GitHub Pages deployment work, and documented the move toward a React/Vite frontend with Flask/MongoDB backend.
+
+## Evidence
+
+- Vite setup PR: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/26
+- Backend setup PR: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/29
+- Deployment issue noted in packet and midterm submission.
+
+## Risks
+
+Deployment and frontend/backend integration were still active risks.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_07.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_07.md
@@ -1,0 +1,19 @@
+# Week 07
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Weekly Sprint Packet - Week7.md](../../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week7.md)
+- Midterm deck: [docs/Midterm/Ulsan_College_Marketplace.pptx](../../../docs/Midterm/Ulsan_College_Marketplace.pptx)
+
+## Summary
+
+Week 07 prepared the midterm pitch, speaker roles, demo reliability plan, and login-focused proof story.
+
+## Evidence
+
+- Live demo link in packet: https://capstonedesign-spring2026-ulsancollege.github.io/campusMarketPlace/
+- Packet describes login as partially implemented, backend setup completed, user stories and issues created, and midterm structure planned.
+
+## Gap
+
+The packet says integration was not fully stable and some proof links were missing.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_08.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_08.md
@@ -1,0 +1,19 @@
+# Week 08
+
+## Materials We Have
+
+- Midterm submission: [docs/Midterm/MIDTERM_SUBMISSION.md](../../../docs/Midterm/MIDTERM_SUBMISSION.md)
+- Midterm deck: [docs/Midterm/Ulsan_College_Marketplace.pptx](../../../docs/Midterm/Ulsan_College_Marketplace.pptx)
+- Sprint 2 summary: [docs/Sprint_Packet/SPRINT_2.md](../../../docs/Sprint_Packet/SPRINT_2.md)
+
+## Summary
+
+No separate Week 08 packet was found. Week 08 appears to be represented by the midterm submission materials and Sprint 2 packet.
+
+## Evidence
+
+The midterm submission documents the live GitHub Pages frontend, signup validation story, deployment workflow, roadmap, speaker roles, and proof of repository activity.
+
+## Note
+
+We do not have a formal weekly sprint packet for this week.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_09.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_09.md
@@ -1,0 +1,19 @@
+# Week 09
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Week_9/Weekly Sprint Packet - Week9.md](../../../docs/Sprint_Packet/Week_9/Weekly%20Sprint%20Packet%20-%20Week9.md)
+- AI audit: [docs/Sprint_Packet/Week_9/AI Code Ownership Audit.md](../../../docs/Sprint_Packet/Week_9/AI%20Code%20Ownership%20Audit.md)
+
+## Summary
+
+Week 09 started MVP verification, login stabilization, frontend-backend connection improvements, and item listing API planning.
+
+## Evidence
+
+- AI ownership audit documents working frontend validation and gaps still understood by the team.
+- Week 09 packet documents login, MongoDB integration, and item API direction.
+
+## Gap
+
+Several evidence links are marked TBD in the weekly packet, so those entries should be treated as claims needing stronger links.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_10.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_10.md
@@ -1,0 +1,19 @@
+# Week 10
+
+## Materials We Have
+
+- Sprint 3 packet: [docs/Sprint_Packet/SPRINT_3.md](../../../docs/Sprint_Packet/SPRINT_3.md)
+- GitHub PR evidence listed in Sprint 3 packet
+
+## Summary
+
+No separate Week 10 weekly packet was found. Sprint 3 documentation says Week 10 focused on QA hardening, API validation, route consistency, and integration bug triage.
+
+## Evidence
+
+- Sprint 3 packet references PR #57 and PR #58 for Week 10 work.
+- The sprint summary lists incomplete automation and integration timing friction as Week 10 issues.
+
+## Note
+
+This week is represented by the sprint-level packet rather than a standalone weekly file.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_11.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_11.md
@@ -1,0 +1,25 @@
+# Week 11
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Week_11/Weekly Sprint Packet - Week11.md](../../../docs/Sprint_Packet/Week_11/Weekly%20Sprint%20Packet%20-%20Week11.md)
+- Sprint 3 packet: [docs/Sprint_Packet/SPRINT_3.md](../../../docs/Sprint_Packet/SPRINT_3.md)
+
+## Summary
+
+Week 11 verified the MVP core flow: campus signup, verification gate, JWT login, dashboard access, item listing API, and post item composer.
+
+## Strong Evidence
+
+- PR #55: replace mock data with real API calls
+- PR #56: malformed JWT subject fix
+- PR #57: signup form lifecycle fix
+- PR #58: GET item detail endpoint
+- PR #59: item listing endpoints
+- PR #60: post item composer form
+- PR #61: item schema validation and MongoDB indexes
+- PR #62: email verification gate
+
+## Risks
+
+Email sending, automated tests, and complete frontend listings page were still listed as gaps.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_12.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_12.md
@@ -1,0 +1,18 @@
+# Week 12
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Week_12/Weekly_Sprint_Packet_Week12.md](../../../docs/Sprint_Packet/Week_12/Weekly_Sprint_Packet_Week12.md)
+- Sprint 4 packet: [docs/Sprint_Packet/SPRINT_4.md](../../../docs/Sprint_Packet/SPRINT_4.md)
+
+## Summary
+
+Week 12 planned the Sprint 4 close-the-gaps work: listings UI, OTP delivery, pytest smoke tests, Cloudinary uploads, and CI enforcement.
+
+## Evidence
+
+The packet is mostly a planning/status document and repeatedly marks work as in progress.
+
+## Gap
+
+Several fields still say "add link" or use placeholders, so this week needs stronger evidence links if the team has them outside the repo.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_13.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_13.md
@@ -1,0 +1,19 @@
+# Week 13
+
+## Materials We Have
+
+- Weekly packet: [docs/Sprint_Packet/Week_13/Weekly Sprint Packet - Week13.md](../../../docs/Sprint_Packet/Week_13/Weekly%20Sprint%20Packet%20-%20Week13.md)
+- Final code in [app.py](../../../app.py) and [Frontend/src](../../../Frontend/src)
+
+## Summary
+
+Week 13 records feature completion for search, dashboard, image upload, item CRUD, authentication, language/currency support, and production deployment configuration.
+
+## Evidence
+
+- Frontend routes exist for Home, Browse, Search, Dashboard, Login, Signup, Messages, ItemDetail, Profile, EditProfile, PublicProfile, and ChangePassword.
+- Backend routes exist for auth, profile, uploads, items, favorites, users, reviews, and messages.
+
+## Note
+
+The packet states many features as shipped but does not include PR links for every item. The final code is the strongest local evidence.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_14.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_14.md
@@ -1,0 +1,19 @@
+# Week 14
+
+## Materials We Have
+
+- Sprint 4 packet: [docs/Sprint_Packet/SPRINT_4.md](../../../docs/Sprint_Packet/SPRINT_4.md)
+- Git history from late May and early June 2026
+- Profile testing notes: [docs/ProfileTesting.md](../../../docs/ProfileTesting.md)
+
+## Summary
+
+No separate Week 14 packet was found. The Sprint 4 packet expected final demo polish, production deployment verification, documentation pass, and demo recording.
+
+## Evidence
+
+Late commits show seller profile, item detail UI, profile button/nav polish, auth session persistence, avatar upload endpoint, API endpoints, and message page work.
+
+## Gap
+
+No formal Week 14 weekly packet exists in the repo.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_15.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_15.md
@@ -1,0 +1,20 @@
+# Week 15
+
+## Materials We Have
+
+- Git history from June 2026
+- Final code in [app.py](../../../app.py) and [Frontend/src](../../../Frontend/src)
+- Profile testing notes: [docs/ProfileTesting.md](../../../docs/ProfileTesting.md)
+
+## Summary
+
+No formal Week 15 packet was found. Git history shows final stabilization and polish work: CI fixes, item detail spacing/alignment, sessionStorage auth behavior, message page layout, message statuses, full-screen layout, and dark mode.
+
+## Evidence
+
+- June 5-7 commits include backend endpoint work, session persistence, CI/frontend test script handling, and item detail improvements.
+- June 10 commits include messages page layout fixes, read receipts, premium visual polish, and dark mode.
+
+## Gap
+
+The repo does not contain a Week 15 sprint packet.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_16.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_16.md
@@ -1,0 +1,18 @@
+# Week 16
+
+## Materials We Have
+
+- Git history from June 12-13, 2026
+- Final portfolio files in this folder
+
+## Summary
+
+No formal Week 16 packet was found. Final commits show dark mode/readability polish, font enhancements, search/category toggle behavior, and listing detail readability improvements.
+
+## Evidence
+
+- Commits on June 12-13 include "Enhance fonts and restore dark mode", "Add live search toggle behavior", "Add search category options toggle", "Add browse category options toggle", and "Improve dark listing detail readability".
+
+## Final Focus
+
+This portfolio organizes the existing semester evidence and documents remaining gaps for final submission.

--- a/portfolio/03-design-and-planning/README.md
+++ b/portfolio/03-design-and-planning/README.md
@@ -1,0 +1,40 @@
+# Design and Planning History
+
+This section links the real planning materials that exist in the repository. Older documents are preserved as evidence of the semester process, even when the final product changed.
+
+## Proposals
+
+- [Project pitch](../../docs/PROJECTPITCH.md)
+- [Project overview](../../docs/PROJECT_1.md)
+- [Midterm submission](../../docs/Midterm/MIDTERM_SUBMISSION.md)
+
+## User Research and User Needs
+
+- [User stories](../../docs/USERSTORIES.md)
+- [Questions](../../docs/questions.md)
+
+## Wireframes
+
+- [Wireframe document](../../docs/WIREFRAME.md)
+
+## Architecture
+
+- [Architecture sketch](../../docs/Architecture_sketch.md)
+- [Design document v1](../../docs/Design%20Doc%20v1.md)
+- [Final architecture](../04-final-product/ARCHITECTURE_FINAL.md)
+
+## Risk and Scope
+
+- [Final MVP scope](../01-project-overview/FINAL_MVP_SCOPE.md)
+- [Scope decisions](../01-project-overview/SCOPE_DECISIONS.md)
+- [Bugs and limitations](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)
+
+## Planning Docs
+
+- [Team agreement](../../docs/TEAMAGREEMENT.md)
+- [Sprint packet folder](../../docs/Sprint_Packet)
+- [Semester journey](../02-semester-journey/SEMESTER_JOURNEY.md)
+
+## Historical Integrity Note
+
+Some early documents describe older plans such as SQLite, Jinja templates, or simpler frontend/backend flows. Those were not rewritten here. They remain useful because they show how the project evolved into the final React + Flask + MongoDB implementation.

--- a/portfolio/03-design-and-planning/architecture/README.md
+++ b/portfolio/03-design-and-planning/architecture/README.md
@@ -1,0 +1,7 @@
+# Architecture
+
+Existing architecture evidence:
+
+- [Architecture sketch](../../../docs/Architecture_sketch.md)
+- [Design document v1](../../../docs/Design%20Doc%20v1.md)
+- [Final architecture](../../04-final-product/ARCHITECTURE_FINAL.md)

--- a/portfolio/03-design-and-planning/planning-docs/README.md
+++ b/portfolio/03-design-and-planning/planning-docs/README.md
@@ -1,0 +1,7 @@
+# Planning Docs
+
+Existing planning evidence:
+
+- [Team agreement](../../../docs/TEAMAGREEMENT.md)
+- [Sprint packet folder](../../../docs/Sprint_Packet)
+- [Semester journey](../../02-semester-journey/SEMESTER_JOURNEY.md)

--- a/portfolio/03-design-and-planning/proposals/README.md
+++ b/portfolio/03-design-and-planning/proposals/README.md
@@ -1,0 +1,7 @@
+# Proposals
+
+Existing proposal evidence is linked rather than duplicated:
+
+- [Project pitch](../../../docs/PROJECTPITCH.md)
+- [Project overview](../../../docs/PROJECT_1.md)
+- [Midterm submission](../../../docs/Midterm/MIDTERM_SUBMISSION.md)

--- a/portfolio/03-design-and-planning/risk-and-scope/README.md
+++ b/portfolio/03-design-and-planning/risk-and-scope/README.md
@@ -1,0 +1,7 @@
+# Risk and Scope
+
+Existing scope and risk evidence:
+
+- [Final MVP scope](../../01-project-overview/FINAL_MVP_SCOPE.md)
+- [Scope decisions](../../01-project-overview/SCOPE_DECISIONS.md)
+- [Bugs and limitations](../../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)

--- a/portfolio/03-design-and-planning/user-research/README.md
+++ b/portfolio/03-design-and-planning/user-research/README.md
@@ -1,0 +1,6 @@
+# User Research
+
+Existing user research and user-need evidence:
+
+- [User stories](../../../docs/USERSTORIES.md)
+- [Questions](../../../docs/questions.md)

--- a/portfolio/03-design-and-planning/wireframes/README.md
+++ b/portfolio/03-design-and-planning/wireframes/README.md
@@ -1,0 +1,5 @@
+# Wireframes
+
+Existing wireframe evidence:
+
+- [Wireframes](../../../docs/WIREFRAME.md)

--- a/portfolio/04-final-product/ARCHITECTURE_FINAL.md
+++ b/portfolio/04-final-product/ARCHITECTURE_FINAL.md
@@ -1,0 +1,103 @@
+# Final Architecture
+
+## Tech Stack
+
+| Area | Technology |
+|---|---|
+| Frontend | React 18, Vite, React Router |
+| Styling | Custom CSS in `Frontend/src/assets/styles/global.css` |
+| Backend | Flask 3 |
+| Database | MongoDB via PyMongo |
+| Auth | JWT, password hashing, OTP verification flow |
+| Images | Local uploads in development, Cloudinary when configured |
+| Email | SendGrid preferred, SMTP fallback |
+| Deployment | GitHub Pages frontend, Render-style backend configuration |
+
+## Major Folders
+
+- `Frontend/`: React + Vite frontend
+- `Frontend/src/routes/`: page-level frontend routes
+- `Frontend/src/components/`: reusable UI pieces
+- `Frontend/src/services/`: API, auth, currency, i18n helpers
+- `app.py`: main Flask backend
+- `models/`: backend model helpers
+- `tests/`: integration test draft/evidence
+- `docs/`: semester documentation
+- `portfolio/`: final handoff portfolio
+
+## Major Frontend Screens
+
+- Home
+- Browse
+- Search
+- Login
+- Signup
+- Dashboard
+- ItemDetail
+- Messages
+- Profile
+- EditProfile
+- PublicProfile
+- ChangePassword
+
+## Major Backend Endpoints
+
+- `GET /api/health`
+- `POST /api/auth/signup`
+- `POST /api/auth/login`
+- `POST /api/auth/verify-email-otp`
+- `POST /api/auth/resend-email-otp`
+- `GET /api/auth/me`
+- `GET /api/profile`
+- `PUT /api/profile`
+- `PUT /api/profile/password`
+- `POST /api/profile/avatar`
+- `DELETE /api/profile/avatar`
+- `POST /api/uploads/image`
+- `GET /api/items`
+- `GET /api/items/<item_id>`
+- `POST /api/items`
+- `PUT /api/items/<item_id>`
+- `POST /api/items/<item_id>/favorite`
+- `GET /api/users/<user_id>`
+- `GET /api/users/<user_id>/reviews`
+- `POST /api/users/<user_id>/reviews`
+- `GET /api/messages/threads`
+- `POST /api/messages/threads`
+- `GET /api/messages/threads/<thread_id>`
+- `POST /api/messages/threads/<thread_id>/read`
+- `GET /api/messages/threads/<thread_id>/messages`
+- `POST /api/messages/threads/<thread_id>/messages`
+
+## Data Model Areas
+
+- Users
+- Email verification records
+- Items/listings
+- Images/avatar URLs
+- Favorite item IDs
+- Message threads and messages
+- Seller reviews
+
+## Text Diagram
+
+```text
+[Student Browser]
+      |
+      v
+[React + Vite Frontend on GitHub Pages]
+      |
+      v
+[Flask API / app.py]
+      |
+      +--> [MongoDB: users, items, messages, reviews]
+      +--> [SendGrid or SMTP: OTP email]
+      +--> [Cloudinary or local uploads: images]
+```
+
+## Evidence
+
+- Backend routes: [app.py](../../app.py)
+- Frontend app: [Frontend/src/App.jsx](../../Frontend/src/App.jsx)
+- API helper: [Frontend/src/services/api.js](../../Frontend/src/services/api.js)
+- Original architecture sketch: [docs/Architecture_sketch.md](../../docs/Architecture_sketch.md)

--- a/portfolio/04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md
+++ b/portfolio/04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md
@@ -1,0 +1,57 @@
+# Deployment and Demo Plan
+
+## How the App Will Be Shown
+
+Primary plan:
+
+1. Open the frontend demo at https://capstonedesign-spring2026-ulsancollege.github.io/campusMarketPlace/
+2. Confirm the backend API is reachable.
+3. Demonstrate signup/login or use a pre-created verified demo account.
+4. Browse/search listings.
+5. Open an item detail page.
+6. Create or update a listing.
+7. Show profile/dashboard features.
+8. Briefly show backend/API evidence in GitHub if needed.
+
+## Required Accounts or Services
+
+- GitHub Pages frontend
+- Backend hosting service, likely Render
+- MongoDB database
+- Optional SendGrid/SMTP for OTP
+- Optional Cloudinary for persistent image uploads
+
+## Local-Run Requirements
+
+- Python virtual environment with `requirements.txt`
+- Node/npm dependencies installed
+- `.env` configured
+- MongoDB available
+- Backend on port `5050`
+- Frontend on port `5173`
+
+## Demo Data
+
+Use controlled demo data:
+
+- One verified buyer account
+- One verified seller account
+- At least three marketplace items across different categories
+- At least one item with an image
+- At least one profile/avatar example if Cloudinary is configured
+
+## Backup Option
+
+- Run locally from the cloned repo.
+- Use screenshots or code walkthrough if hosting fails.
+- Use manually pre-verified database users if email delivery fails.
+- Use existing image URLs or local upload fallback if Cloudinary fails.
+- Show GitHub PR/commit evidence for features that cannot be live-demonstrated.
+
+## Known Risks
+
+- Backend deployment may be down or sleeping.
+- MongoDB/Cloudinary/SendGrid credentials may be missing or expired.
+- Email OTP cannot be demonstrated without provider configuration.
+- Network issues can break live demo flow.
+- Tests are not a full automated safety net yet.

--- a/portfolio/04-final-product/FINAL_MVP_DEMO.md
+++ b/portfolio/04-final-product/FINAL_MVP_DEMO.md
@@ -1,0 +1,41 @@
+# Final MVP Demo
+
+## Main User Flow
+
+1. Open the frontend demo or run the app locally.
+2. Create an account with a campus email ending in `@office.uc.ac.kr`.
+3. Verify the email OTP if email delivery is configured.
+4. Log in and reach the authenticated experience.
+5. Browse marketplace listings.
+6. Search or filter by category.
+7. Open an item detail page and review seller/item information.
+8. Create a new listing with item details and image support.
+9. Use dashboard/profile features to manage user state.
+10. Use the backup path if external email/image/deployment services fail.
+
+## Access
+
+- Frontend demo: https://capstonedesign-spring2026-ulsancollege.github.io/campusMarketPlace/
+- Repository: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace
+- Backend local URL by default: `http://localhost:5050`
+- Frontend local URL by default: `http://localhost:5173`
+
+## Demo Credentials
+
+No public demo credentials are committed in this repo. For a live demo, use a pre-created test account or create one during rehearsal with a valid `@office.uc.ac.kr` email. If OTP email delivery is unavailable, use a locally pre-verified database account for the demo and explain the limitation.
+
+## Demo Notes
+
+- Email OTP delivery requires SendGrid or SMTP settings.
+- Cloudinary image upload requires Cloudinary environment variables.
+- MongoDB must be reachable for backend data flows.
+- The frontend can be shown from GitHub Pages even if backend services are unavailable, but the full MVP requires the Flask API.
+
+## Evidence Links
+
+- Final backend: [app.py](../../app.py)
+- Frontend routes: [Frontend/src/routes](../../Frontend/src/routes)
+- API service: [Frontend/src/services/api.js](../../Frontend/src/services/api.js)
+- README run instructions: [README.md](../../README.md)
+- Week 11 MVP verification: [Week 11 packet](../02-semester-journey/weekly-sprints/WEEK_11.md)
+- Week 13 feature completion: [Week 13 packet](../02-semester-journey/weekly-sprints/WEEK_13.md)

--- a/portfolio/04-final-product/SETUP_AND_RUN_GUIDE.md
+++ b/portfolio/04-final-product/SETUP_AND_RUN_GUIDE.md
@@ -1,0 +1,91 @@
+# Setup and Run Guide
+
+## Required Software
+
+- Python 3
+- Node.js and npm
+- MongoDB local instance or MongoDB Atlas connection string
+- Optional: SendGrid or SMTP account for OTP emails
+- Optional: Cloudinary account for persistent image uploads
+
+## Clone
+
+```bash
+git clone https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace.git
+cd campusMarketPlace
+```
+
+## Backend Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Edit `.env` with safe local values:
+
+- `MONGODB_URI`
+- `MONGODB_DB_NAME`
+- `JWT_SECRET`
+- `FRONTEND_ORIGIN`
+- Optional `SENDGRID_API_KEY`, `SENDGRID_FROM`, SMTP variables
+- Optional Cloudinary variables
+
+Run the backend:
+
+```bash
+source .venv/bin/activate
+python app.py
+```
+
+Default backend port: `5050`.
+
+## Frontend Setup
+
+```bash
+npm install
+npm --prefix Frontend install
+npm run dev
+```
+
+Default Vite URL: `http://localhost:5173`.
+
+## Build
+
+```bash
+npm run build
+```
+
+## Test Commands
+
+Frontend placeholder test:
+
+```bash
+npm --prefix Frontend test
+```
+
+Backend/integration tests:
+
+```bash
+TEST_MONGODB_URI="mongodb://localhost:27017/campus_marketplace_test" pytest
+```
+
+Current limitation: [tests/test_profile_endpoints.py](../../tests/test_profile_endpoints.py) expects a Flask `client` fixture, but the repo does not currently include `conftest.py`. Add that fixture before expecting the pytest file to run end-to-end in CI.
+
+## Seed Data
+
+No seed script was found. For demo data, create users/listings through the app or insert controlled test documents in a local MongoDB database.
+
+## Troubleshooting
+
+- If signup rejects an email, confirm it ends with `@office.uc.ac.kr`.
+- If OTP email is not received, confirm SendGrid/SMTP variables and sender verification.
+- If image uploads fail in production-like environments, configure Cloudinary variables.
+- If frontend API calls fail, confirm the backend is running and CORS/`FRONTEND_ORIGIN` are configured.
+- If GitHub Pages routing fails, confirm the frontend uses the configured Vite base path.
+
+## Do Not Commit Secrets
+
+Use `.env` locally and keep real API keys, database credentials, and JWT secrets out of Git.

--- a/portfolio/04-final-product/screenshots/README.md
+++ b/portfolio/04-final-product/screenshots/README.md
@@ -1,0 +1,12 @@
+# Screenshots
+
+Add final screenshots here if the team captures them before submission.
+
+Recommended screenshots:
+
+- Homepage/listings
+- Signup/login
+- Item detail
+- Dashboard/manage listing
+- Profile/avatar
+- Messages or seller profile, if included in the final demo

--- a/portfolio/05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md
+++ b/portfolio/05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md
@@ -1,0 +1,21 @@
+# Bugs and Limitations
+
+| Bug or limitation | Severity | Status | Evidence | Workaround or next step |
+|---|---|---|---|---|
+| OTP email delivery requires SendGrid or SMTP configuration | P1 | Accepted | [README.md](../../README.md), [app.py](../../app.py) | Use configured provider or pre-verified demo account |
+| Cloudinary uploads require external credentials | P2 | Accepted | [README.md](../../README.md), [app.py](../../app.py) | Configure Cloudinary or use local dev fallback |
+| Automated backend tests need a Flask test client fixture | P2 | Open | [tests/test_profile_endpoints.py](../../tests/test_profile_endpoints.py) | Add `conftest.py` and test database setup |
+| Frontend tests are a placeholder | P2 | Open | [Frontend/package.json](../../Frontend/package.json) | Add real component/integration tests |
+| Some weekly sprint packets are missing | P3 | Accepted | [weekly-sprints](../02-semester-journey/weekly-sprints) | Document gaps honestly |
+| Some weekly packets contain placeholders/TBD links | P3 | Accepted | [docs/Sprint_Packet](../../docs/Sprint_Packet) | Replace with links if team has external evidence |
+| Live demo depends on GitHub Pages, backend hosting, MongoDB, and network | P1 | Accepted | [DEPLOYMENT_AND_DEMO_PLAN.md](../04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md) | Rehearse local backup |
+| No committed seed-data script | P3 | Open | Repo inspection | Add seed script or prepare manual demo data |
+| Admin moderation not implemented | P3 | Accepted | [SCOPE_DECISIONS.md](../01-project-overview/SCOPE_DECISIONS.md) | Treat as post-MVP |
+| Payment/shipping not implemented | P3 | Accepted | [SCOPE_DECISIONS.md](../01-project-overview/SCOPE_DECISIONS.md) | Keep out of final MVP |
+
+Severity guide:
+
+- P0: final demo cannot work
+- P1: core feature broken or unreliable
+- P2: important but workaround exists
+- P3: polish or nice improvement

--- a/portfolio/05-qa-and-stabilization/QA_REPORT.md
+++ b/portfolio/05-qa-and-stabilization/QA_REPORT.md
@@ -1,0 +1,65 @@
+# QA Report
+
+## Core Flow Checklist
+
+| Check | Status | Evidence |
+|---|---|---|
+| Frontend builds with Vite | Needs final run before submission | [Frontend/package.json](../../Frontend/package.json) |
+| Backend starts locally | Needs final run before submission | [app.py](../../app.py) |
+| Campus email validation | Implemented | [app.py](../../app.py), [README.md](../../README.md) |
+| Strong password validation | Implemented | [app.py](../../app.py) |
+| Signup endpoint | Implemented | [app.py](../../app.py) |
+| Login endpoint | Implemented | [app.py](../../app.py) |
+| OTP verification endpoints | Implemented with service dependency | [app.py](../../app.py) |
+| Browse listings | Implemented | [Frontend/src/routes/Browse.jsx](../../Frontend/src/routes/Browse.jsx) |
+| Item detail | Implemented | [Frontend/src/routes/ItemDetail.jsx](../../Frontend/src/routes/ItemDetail.jsx) |
+| Create/update items | Implemented | [app.py](../../app.py), [Frontend/src/routes/Dashboard.jsx](../../Frontend/src/routes/Dashboard.jsx) |
+| Profile/avatar flow | Implemented; manual test notes exist | [docs/ProfileTesting.md](../../docs/ProfileTesting.md) |
+| Messaging flow | Implemented but should be demo-tested | [Frontend/src/routes/Messages.jsx](../../Frontend/src/routes/Messages.jsx), [app.py](../../app.py) |
+
+## Manual Test Evidence
+
+- Profile testing notes: [docs/ProfileTesting.md](../../docs/ProfileTesting.md)
+- Week 11 verification packet: [WEEK_11.md](../02-semester-journey/weekly-sprints/WEEK_11.md)
+- Week 13 feature completion packet: [WEEK_13.md](../02-semester-journey/weekly-sprints/WEEK_13.md)
+
+## Automated Tests
+
+The repo contains [tests/test_profile_endpoints.py](../../tests/test_profile_endpoints.py), which covers:
+
+- Signup/login and avatar upload/delete
+- Owner item status update
+- Favorite item persistence
+- Seller review creation/fetch
+
+Limitation: the test file is skipped unless `TEST_MONGODB_URI` is set and expects a Flask test client fixture that is not included in the repo.
+
+## CI Evidence
+
+- GitHub workflows exist in [.github/workflows](../../.github/workflows)
+- Frontend test script currently returns success with "No frontend tests"
+- CI should be improved to run real backend tests after a test fixture is added
+
+## Browser or Device Checks
+
+- The app is built as a responsive React web app.
+- Profile testing notes include browser-based local steps.
+- Final rehearsal should include desktop and mobile viewport checks.
+
+## Accessibility Checks
+
+No formal accessibility audit file was found. Basic checks before demo should include keyboard navigation, visible focus states, readable contrast in dark mode, labels/placeholders, and alt text for meaningful images.
+
+## Security Basics
+
+- Password strength validation exists.
+- Campus email validation exists.
+- JWT secret configuration is documented.
+- Production-like image storage behavior avoids silently using ephemeral local storage when Cloudinary is missing.
+- Secrets must stay in `.env` and not be committed.
+
+## Deployment Reliability
+
+- Frontend GitHub Pages deployment is documented.
+- Backend deployment depends on environment variables and external services.
+- Backup demo should be ready.

--- a/portfolio/05-qa-and-stabilization/qa-checklists/CORE_FLOW_CHECKLIST.md
+++ b/portfolio/05-qa-and-stabilization/qa-checklists/CORE_FLOW_CHECKLIST.md
@@ -1,0 +1,18 @@
+# Core Flow Checklist
+
+- [ ] Backend starts locally with `.env`
+- [ ] Frontend starts locally with Vite
+- [ ] `GET /api/health` returns OK
+- [ ] Signup rejects non-campus email
+- [ ] Signup accepts `@office.uc.ac.kr` email
+- [ ] OTP verification path is tested or fallback is prepared
+- [ ] Login returns token for verified account
+- [ ] Browse page loads listings
+- [ ] Search/category behavior works
+- [ ] Item detail page loads
+- [ ] Seller can create an item
+- [ ] Seller can update item status
+- [ ] Profile page loads current user details
+- [ ] Avatar upload/delete works when storage is configured
+- [ ] Messaging page/threads are demo-tested or skipped with explanation
+- [ ] Backup demo path is rehearsed

--- a/portfolio/05-qa-and-stabilization/refactor-evidence/README.md
+++ b/portfolio/05-qa-and-stabilization/refactor-evidence/README.md
@@ -1,0 +1,10 @@
+# Refactor Evidence
+
+Useful stabilization/refactor evidence:
+
+- CI/frontend test script adjustments appear in git history around June 6-7, 2026.
+- Auth session behavior changed to `sessionStorage` in git history on June 7, 2026.
+- Message page layout and read receipt/status work appears in git history on June 10, 2026.
+- Dark mode, font, search/category toggle, and item detail readability polish appears in git history on June 10-13, 2026.
+
+Use `git log --oneline --date=short --all` for exact commit hashes.

--- a/portfolio/05-qa-and-stabilization/test-evidence/README.md
+++ b/portfolio/05-qa-and-stabilization/test-evidence/README.md
@@ -1,0 +1,9 @@
+# Test Evidence
+
+Current test-related evidence:
+
+- [tests/test_profile_endpoints.py](../../../tests/test_profile_endpoints.py)
+- [docs/ProfileTesting.md](../../../docs/ProfileTesting.md)
+- [QA report](../QA_REPORT.md)
+
+Known limitation: pytest integration needs a test client fixture before it can run cleanly in CI.

--- a/portfolio/06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md
+++ b/portfolio/06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md
@@ -1,0 +1,76 @@
+# AI Code Ownership Audit
+
+## Rule
+
+AI-assisted work only counts if the team can run it, explain it, test it, debug it, and link evidence.
+
+## Existing Evidence
+
+- Original audit: [docs/Sprint_Packet/Week_9/AI Code Ownership Audit.md](../../docs/Sprint_Packet/Week_9/AI%20Code%20Ownership%20Audit.md)
+- Week 11 AI/ownership check: [WEEK_11.md](../02-semester-journey/weekly-sprints/WEEK_11.md)
+- Final code: [app.py](../../app.py), [Frontend/src](../../Frontend/src)
+
+## AI Tools Used
+
+- GitHub Copilot, according to the Week 9 and Week 11 audit materials
+- ChatGPT/Claude/Gemini-style tools, according to sprint packet notes
+
+## What AI Helped With
+
+- Form validation and regex suggestions
+- Bootstrap/responsive UI guidance
+- Vite/build configuration guidance
+- Backend route/schema boilerplate
+- Debugging and API implementation suggestions
+- Sprint packet structure and wording
+- PR summary/review wording
+
+## Human Review and Changes
+
+Humans reviewed, customized, and tested the project against the campus marketplace requirements:
+
+- Campus email requirement changed to `@office.uc.ac.kr`
+- Password strength and signup validation were adjusted for the app
+- Flask/MongoDB routes were integrated into the real backend
+- Frontend API calls were connected to real backend responses
+- Environment variable behavior was documented for deployment
+- Sprint packets and portfolio documents link evidence rather than treating AI output as proof by itself
+
+## Code Areas Each Student Can Explain
+
+| Student | Code/doc area | Evidence |
+|---|---|---|
+| Sudarshan Rai | Documentation, backend setup, final portfolio, setup/run guide, Sprint 4 planning | [TEAMAGREEMENT.md](../../docs/TEAMAGREEMENT.md), [SPRINT_4.md](../../docs/Sprint_Packet/SPRINT_4.md) |
+| Sagar Sob | Backend/API and QA ownership in sprint materials | [Week 11 packet](../../docs/Sprint_Packet/Week_11/Weekly%20Sprint%20Packet%20-%20Week11.md) |
+| Gayatri K. Bhandari | Frontend, demo driver, deployment/front-end integration evidence | [Week 11 packet](../../docs/Sprint_Packet/Week_11/Weekly%20Sprint%20Packet%20-%20Week11.md) |
+| Aayuska Rai | UI/UX, AI steward, Sprint 4/Week 13 materials | [Week 13 packet](../../docs/Sprint_Packet/Week_13/Weekly%20Sprint%20Packet%20-%20Week13.md) |
+| Ananda Tamang | Database, QA, email/OTP work in sprint materials | [Week 11 packet](../../docs/Sprint_Packet/Week_11/Weekly%20Sprint%20Packet%20-%20Week11.md) |
+
+## Confusing or Risky Code Areas
+
+| Area | Risk | Mitigation |
+|---|---|---|
+| OTP email delivery | Requires external provider configuration | Rehearse with SendGrid/SMTP or use pre-verified account |
+| Cloudinary image upload | Requires external credentials | Configure env vars or use local fallback for local demo |
+| Integration tests | Test file exists but fixture is missing | Add `conftest.py` and test DB setup |
+| Messaging | More complex than core marketplace demo | Keep backup demo path and explain scope |
+| Deployment | Depends on GitHub Pages, Render, MongoDB, Cloudinary, email provider | Rehearse local run |
+
+## Representative AI-Assisted PRs and Evidence
+
+- PR #26 Vite setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/26
+- PR #29 backend setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/29
+- PR #55 real API calls: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/55
+- PR #56 JWT fix: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/56
+- PR #57 signup lifecycle fix: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/57
+- PR #58 item detail endpoint: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/58
+- PR #59 item listing endpoints: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/59
+- PR #60 post item composer: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/60
+- PR #61 item schema/indexes: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/61
+- PR #62 email verification gate: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/62
+
+## Remaining Ownership Risks
+
+- Every student should personally verify that they can explain the code area listed for them.
+- Each student should add their own individual portfolio page before submission.
+- The team should rehearse technical questions around auth, MongoDB collections, item ownership, CORS, image uploads, email OTP, and deployment.

--- a/portfolio/06-ai-and-code-ownership/AI_USE_SUMMARY.md
+++ b/portfolio/06-ai-and-code-ownership/AI_USE_SUMMARY.md
@@ -1,0 +1,30 @@
+# AI Use Summary
+
+## Summary
+
+AI tools were used as support for code suggestions, debugging ideas, documentation structure, and sprint packet wording. The team remains responsible for the final code and must be able to run, explain, test, debug, and defend any AI-assisted work.
+
+## Areas Where AI Helped
+
+- Frontend validation examples
+- Responsive layout suggestions
+- Vite/build setup guidance
+- Flask route and MongoDB schema implementation ideas
+- Debugging JWT/auth issues
+- Sprint packet and portfolio organization
+- PR descriptions and review summaries
+
+## Human Responsibilities
+
+- Check generated code against real project requirements
+- Replace generic examples with campus-specific rules
+- Test API and UI flows
+- Keep secrets out of the repo
+- Document limitations honestly
+- Explain the code during final defense
+
+## Evidence
+
+- [Original AI audit](../../docs/Sprint_Packet/Week_9/AI%20Code%20Ownership%20Audit.md)
+- [AI code ownership audit](AI_CODE_OWNERSHIP_AUDIT.md)
+- [QA report](../05-qa-and-stabilization/QA_REPORT.md)

--- a/portfolio/06-ai-and-code-ownership/representative-prs/README.md
+++ b/portfolio/06-ai-and-code-ownership/representative-prs/README.md
@@ -1,0 +1,12 @@
+# Representative PRs
+
+- Vite setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/26
+- Backend setup: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/29
+- Real API calls: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/55
+- JWT fix: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/56
+- Signup lifecycle fix: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/57
+- Item detail endpoint: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/58
+- Item listing endpoints: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/59
+- Post item composer: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/60
+- Item schema/indexes: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/61
+- Email verification gate: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace/pull/62

--- a/portfolio/07-final-presentation/BACKUP_DEMO.md
+++ b/portfolio/07-final-presentation/BACKUP_DEMO.md
@@ -1,0 +1,50 @@
+# Backup Demo Plan
+
+## Backup Triggers
+
+Use the backup plan if:
+
+- GitHub Pages does not load
+- Backend hosting is asleep or unavailable
+- MongoDB connection fails
+- OTP email is delayed
+- Cloudinary upload fails
+- Classroom network blocks a service
+
+## Backup Order
+
+1. Run the app locally.
+2. Use a pre-verified demo account.
+3. Use existing demo listings.
+4. Skip live OTP delivery and explain provider dependency.
+5. Use local image fallback or existing image URLs.
+6. Show GitHub code evidence if live UI fails.
+7. Show sprint/portfolio evidence for completed work.
+
+## Local Commands
+
+Backend:
+
+```bash
+source .venv/bin/activate
+python app.py
+```
+
+Frontend:
+
+```bash
+npm run dev
+```
+
+## Screens or Files to Have Ready
+
+- [Final MVP Demo](../04-final-product/FINAL_MVP_DEMO.md)
+- [Setup and Run Guide](../04-final-product/SETUP_AND_RUN_GUIDE.md)
+- [Architecture Final](../04-final-product/ARCHITECTURE_FINAL.md)
+- [QA Report](../05-qa-and-stabilization/QA_REPORT.md)
+- [Bugs and Limitations](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)
+- [AI Code Ownership Audit](../06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md)
+
+## Message to Instructor if Backup Is Needed
+
+The live service depends on external deployment, database, email, and image storage configuration. The local/code evidence shows the implemented routes and UI, and the portfolio documents which parts need external credentials.

--- a/portfolio/07-final-presentation/FINAL_PRESENTATION_SCRIPT.md
+++ b/portfolio/07-final-presentation/FINAL_PRESENTATION_SCRIPT.md
@@ -1,0 +1,47 @@
+# Final Presentation Script
+
+Maximum time: 15 minutes.
+
+## 1. Project Story - 2 minutes
+
+CampusMarketplace solves a simple campus problem: students need a safer, more relevant way to buy and sell items with other students. General marketplaces are too broad, and group chats are hard to search or trust. Our solution is a campus-focused marketplace for Ulsan College students, centered on campus email verification and student-to-student exchange.
+
+## 2. Live MVP Demo - 5 minutes
+
+Demo path:
+
+1. Open the frontend.
+2. Show signup/login with campus email rule.
+3. Browse marketplace listings.
+4. Use search or category browsing.
+5. Open an item detail page.
+6. Show seller/profile information.
+7. Create or update a listing from the authenticated flow.
+8. Mention image upload and OTP requirements if external services are not configured live.
+
+## 3. Semester Journey - 2 minutes
+
+The project started with pitch, team agreement, user stories, wireframes, and architecture planning. Around midterm, the team focused on proving a smaller deployed frontend and auth story. In Sprint 3, the work shifted to MVP verification: JWT login, verification gate, item endpoints, and real API calls. In Sprint 4 and the final weeks, the product gained search, dashboard, image support, profiles, reviews, messaging endpoints, dark mode, and final polish.
+
+## 4. QA and Engineering Evidence - 2 minutes
+
+Show the QA report and explain that the team has manual test notes, endpoint-level integration test drafts, and sprint packets documenting bugs and risks. Be honest: the test suite needs a missing fixture before it becomes strong CI evidence, and frontend tests are still placeholder-level.
+
+## 5. AI Use and Code Ownership - 1 minute
+
+AI tools helped with suggestions, boilerplate, debugging, and documentation structure. The team reviewed and adapted the work for the real campus marketplace. AI-assisted code only counts where the team can explain and run it.
+
+## 6. Technical Defense - 3 minutes
+
+Be ready to answer:
+
+- Why React + Vite?
+- Why Flask + MongoDB?
+- How does JWT login work?
+- How do item ownership checks work?
+- What happens if email, Cloudinary, or deployment services fail?
+- What would be improved next?
+
+## Closing
+
+CampusMarketplace is not mystery code. It has a visible repo, final docs, linked evidence, known limitations, and a clear demo path.

--- a/portfolio/07-final-presentation/TECHNICAL_DEFENSE_PREP.md
+++ b/portfolio/07-final-presentation/TECHNICAL_DEFENSE_PREP.md
@@ -1,0 +1,32 @@
+# Technical Defense Prep
+
+## Likely Questions
+
+| Question | Prepared answer |
+|---|---|
+| What problem does this solve? | It gives Ulsan College students a campus-focused place to buy/sell items with more trust and relevance than public marketplaces. |
+| Why campus email? | The email domain creates a basic trust gate so the marketplace is scoped to students. |
+| Why React + Vite? | Vite gave the team a fast frontend dev/build workflow, and React made routing and reusable components easier. |
+| Why Flask? | Flask is lightweight, Python-based, and practical for capstone API development. |
+| Why MongoDB? | Listings, users, messages, and reviews fit flexible document storage, and the team planned MongoDB during early architecture changes. |
+| How is auth handled? | The backend validates credentials and issues JWTs. Protected endpoints read the Bearer token and identify the current user. |
+| How is ownership enforced? | Item update routes compare the authenticated user ID with the item seller ID before allowing edits. |
+| How are images stored? | The backend supports local uploads for development and Cloudinary when configured. |
+| What if OTP email fails? | Use configured SendGrid/SMTP for production; for demo, use a pre-verified account as backup. |
+| What are the biggest limitations? | External service configuration, incomplete automated tests, and missing formal weekly evidence for some weeks. |
+| What would you improve next? | Add real CI tests, seed data, stronger messaging UX, admin moderation, and better deployment monitoring. |
+
+## Code Areas to Show
+
+- Auth routes in [app.py](../../app.py)
+- Item routes in [app.py](../../app.py)
+- Frontend API helper in [Frontend/src/services/api.js](../../Frontend/src/services/api.js)
+- Dashboard/listing UI in [Frontend/src/routes/Dashboard.jsx](../../Frontend/src/routes/Dashboard.jsx)
+- Browse/search UI in [Frontend/src/routes/Browse.jsx](../../Frontend/src/routes/Browse.jsx) and [Frontend/src/routes/Search.jsx](../../Frontend/src/routes/Search.jsx)
+
+## Honest Limitations to State
+
+- The app needs configured services for a complete hosted demo.
+- Automated tests exist as a draft but need fixture setup.
+- Some semester docs are incomplete or placeholder-heavy.
+- Other team members still need to add their individual portfolio pages.

--- a/portfolio/07-final-presentation/slides/README.md
+++ b/portfolio/07-final-presentation/slides/README.md
@@ -1,0 +1,9 @@
+# Slides
+
+Slides are optional according to the final instructions.
+
+Existing presentation evidence:
+
+- Midterm deck: [docs/Midterm/Ulsan_College_Marketplace.pptx](../../../docs/Midterm/Ulsan_College_Marketplace.pptx)
+
+Add the final slide deck or PDF export here if the team uses slides for the final presentation.

--- a/portfolio/08-individual-portfolios/ANANDA_TAMANG.md
+++ b/portfolio/08-individual-portfolios/ANANDA_TAMANG.md
@@ -1,0 +1,58 @@
+# Ananda Tamang Individual Portfolio
+
+## Role
+
+Database/backend contributor, project manager during parts of the semester, QA lead during MVP verification and Sprint 4, and contributor to the MongoDB/authentication direction.
+
+## Strongest Contributions
+
+- Helped define and support the database/backend direction for the project.
+- Served as PM in early and MVP verification sprint materials.
+- Helped track QA and core-flow verification during later sprints.
+- Supported MongoDB, authentication, and OTP/email-related planning in sprint packets.
+- Contributed to the team evidence trail through sprint planning, QA notes, and ownership documentation.
+
+## Evidence Links
+
+- Team role evidence: [docs/TEAMAGREEMENT.md](../../docs/TEAMAGREEMENT.md)
+- Project overview role evidence: [docs/PROJECT_1.md](../../docs/PROJECT_1.md)
+- Week 02 PM/database role evidence: [docs/Sprint_Packet/Weekly Sprint Packet - Week2.md](../../docs/Sprint_Packet/Weekly%20Sprint%20Packet%20-%20Week2.md)
+- Sprint 3 PM evidence: [docs/Sprint_Packet/SPRINT_3.md](../../docs/Sprint_Packet/SPRINT_3.md)
+- Week 09 PM evidence: [docs/Sprint_Packet/Week_9/Weekly Sprint Packet - Week9.md](../../docs/Sprint_Packet/Week_9/Weekly%20Sprint%20Packet%20-%20Week9.md)
+- Week 11 QA lead evidence: [docs/Sprint_Packet/Week_11/Weekly Sprint Packet - Week11.md](../../docs/Sprint_Packet/Week_11/Weekly%20Sprint%20Packet%20-%20Week11.md)
+- Week 12 QA lead evidence: [docs/Sprint_Packet/Week_12/Weekly_Sprint_Packet_Week12.md](../../docs/Sprint_Packet/Week_12/Weekly_Sprint_Packet_Week12.md)
+- AI/code ownership evidence: [docs/Sprint_Packet/Week_9/AI Code Ownership Audit.md](../../docs/Sprint_Packet/Week_9/AI%20Code%20Ownership%20Audit.md)
+
+## One Area I Can Explain Clearly
+
+I can explain the database and backend role in the project at a high level: MongoDB stores users, items, messages, favorites, and reviews; Flask exposes API routes; and authenticated actions use JWT tokens to connect requests to the current user.
+
+I can also explain how QA connects to the MVP: the team had to verify signup, login, item posting, item browsing, profile behavior, and known limitations before the final demo.
+
+## My AI Use
+
+I used AI tools as support for understanding implementation ideas, debugging direction, and organizing sprint/QA documentation. I still had to check outputs against the actual project, test behavior, and make sure the work matched our campus marketplace requirements.
+
+## One Problem I Helped Solve
+
+I helped keep the project focused on backend/database readiness and MVP verification. The project had many possible features, so the important work was making the core marketplace flow understandable and demoable.
+
+## What I Learned
+
+I learned how important backend configuration is: MongoDB, JWT secrets, OTP email, and image storage all affect whether a feature works in a real demo. I also learned that QA evidence needs to be collected while building, not only at the end.
+
+## What I Am Proud Of
+
+I am proud that the team moved from an idea and early frontend into a real full-stack project with authentication, marketplace items, profiles, and final documentation.
+
+## What I Should Have Done Better
+
+I should have added more complete evidence links and receipts during each sprint, especially for database and QA work. Some weekly packets still have placeholders, which makes final proof harder.
+
+## What I Would Improve Next
+
+I would add a proper test database setup, a pytest `conftest.py` fixture, seed demo data, and stronger CI checks so the backend can be verified automatically.
+
+## Skill I Want to Continue Developing
+
+I want to continue developing backend/database testing skills, especially writing tests that prove Flask API routes work correctly with MongoDB.

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -1,0 +1,33 @@
+# CampusMarketplace Final Portfolio
+
+This portfolio is the final handoff package for CampusMarketplace, a campus-only marketplace for Ulsan College students.
+
+## Quick Links
+
+- [Project Summary](01-project-overview/PROJECT_SUMMARY.md)
+- [Final MVP Scope](01-project-overview/FINAL_MVP_SCOPE.md)
+- [Scope Decisions](01-project-overview/SCOPE_DECISIONS.md)
+- [Semester Journey](02-semester-journey/SEMESTER_JOURNEY.md)
+- [Design and Planning History](03-design-and-planning/README.md)
+- [Final MVP Demo](04-final-product/FINAL_MVP_DEMO.md)
+- [Setup and Run Guide](04-final-product/SETUP_AND_RUN_GUIDE.md)
+- [Final Architecture](04-final-product/ARCHITECTURE_FINAL.md)
+- [Deployment and Demo Plan](04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md)
+- [QA Report](05-qa-and-stabilization/QA_REPORT.md)
+- [Bugs and Limitations](05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)
+- [AI Code Ownership Audit](06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md)
+- [AI Use Summary](06-ai-and-code-ownership/AI_USE_SUMMARY.md)
+- [Final Presentation Script](07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)
+- [Technical Defense Prep](07-final-presentation/TECHNICAL_DEFENSE_PREP.md)
+- [Backup Demo Plan](07-final-presentation/BACKUP_DEMO.md)
+- [Individual Portfolio: Ananda Tamang](08-individual-portfolios/ANANDA_TAMANG.md)
+
+## Source Repository
+
+- Repository: https://github.com/CapstoneDesign-Spring2026-UlsanCollege/campusMarketPlace
+- Frontend demo: https://capstonedesign-spring2026-ulsancollege.github.io/campusMarketPlace/
+- Backend API evidence in repo: [`app.py`](../app.py)
+
+## Portfolio Note
+
+This portfolio links the work that exists in the repository. Some weeks have full sprint packets, some weeks only have partial or template documents, and some weeks have no formal packet. Those gaps are documented honestly in the weekly files.


### PR DESCRIPTION
## Summary
- Added the required final `portfolio/` folder for the capstone final submission.
- Organized existing semester evidence into overview, journey, planning, final product, QA, AI ownership, presentation, and individual portfolio sections.
- Added Ananda Tamang’s individual portfolio page and documented honest gaps where weekly evidence was missing or incomplete.

## Linked Issue
Relates to final portfolio submission requirements.  
No GitHub Issue was created for this final documentation package.

## Changes
- Created `portfolio/README.md` as the main entry point.
- Added project overview docs: project summary, final MVP scope, and scope decisions.
- Added weekly files `WEEK_01.md` through `WEEK_16.md`.
- Added sprint summaries for Sprint 1, Sprint 2, Sprint 3, Sprint 4, and Final Sprint.
- Added final product docs: demo guide, setup/run guide, final architecture, and deployment/demo plan.
- Added QA docs: QA report, bugs and limitations, core-flow checklist, test evidence, and refactor evidence.
- Added AI/code ownership docs and representative PR links.
- Added final presentation script, technical defense prep, backup demo plan, and slides placeholder.
- Added individual portfolio page for Ananda Tamang.

## How Tested (required)
- [x] Ran local portfolio file inventory:
  ```bash
  find portfolio -type f | sort