### PR TITLE
fix: repair navbar build syntax

### DIFF
--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -181,6 +181,11 @@ export default function Navbar({
             )}
             {renderActionButton({ className: 'nav-signout', icon: iconLabels.signout, label: t(language, 'navbar.signOut'), onClick: handleSignOut })}
           </>
+        ) : (
+          <>
+            {renderActionLink({ to: '/', end: true, icon: iconLabels.home, label: t(language, 'navbar.home') })}
+            {isAuthenticated ? renderActionLink({ to: '/profile', icon: iconLabels.profile, label: t(language, 'navbar.profile') }) : renderActionLink({ to: '/login', icon: iconLabels.login, label: 'Login' })}
+            {!isAuthenticated ? renderActionLink({ to: '/signup', icon: iconLabels.signup, label: 'Sign Up' }) : null}
             {isAuthenticated ? (
               renderActionButton({ className: 'nav-signout', icon: iconLabels.signout, label: t(language, 'navbar.signOut'), onClick: handleSignOut })
             ) : null}


### PR DESCRIPTION
## Summary
- Fixed a JSX syntax error in `Navbar.jsx` that caused the GitHub Pages build to fail.
- Restored the correct authenticated/unauthenticated navbar conditional rendering.
- Confirmed the frontend production build works locally.

## Linked Issue
Relates to the failing GitHub Actions build for the final portfolio merge.  
No GitHub Issue was created for this build-fix PR.

## Changes
- Repaired the malformed `showAuthNav ? (...) : (...)` JSX block in `Frontend/src/components/Navbar.jsx`.
- Restored the unauthenticated navbar links for Home, Login, and Sign Up.
- Kept the fix scoped to the navbar build error only.

## How Tested (required)
- [x] Ran locally:
  ```bash
  cd Frontend
  npm run build