### PR TITLE
docs: refresh portfolio verification note

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -31,3 +31,7 @@ This portfolio is the final handoff package for CampusMarketplace, a campus-only
 ## Portfolio Note
 
 This portfolio links the work that exists in the repository. Some weeks have full sprint packets, some weeks only have partial or template documents, and some weeks have no formal packet. Those gaps are documented honestly in the weekly files.
+
+## Verification Note
+
+After the portfolio was merged, the frontend build was repaired and verified on `main`. The portfolio contains documentation only; the app build is checked by the repository CI.


### PR DESCRIPTION
## Summary
- Refreshed `portfolio/README.md` with a short verification note.
- This gives the `portfolio/` folder a new commit after the frontend build fix, so GitHub no longer shows the old failed portfolio commit as the latest portfolio status.
- Confirmed the portfolio links and frontend build still pass.

## Linked Issue
Relates to the failed status shown on the `portfolio/` folder page.  
No GitHub Issue was created for this small status-refresh/docs PR.

## Changes
- Added a “Verification Note” section to `portfolio/README.md`.
- Clarified that the portfolio is documentation-only and the app build is checked by repository CI.
- Kept the change limited to one documentation file.

## How Tested (required)
- [x] Ran locally:
  ```bash
  cd Frontend
  npm run build